### PR TITLE
Exclude code coverage generated files from code style check

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+# Coverage directory used by tools like istanbul
+coverage


### PR DESCRIPTION
NYC code coverage report generates js files, which we don't need to check for correct syntax.