### PR TITLE
Simplest RabbitMQ via Docker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install dependencies `yarn install` or `npm install`
 #### Available services
 - `localhost:5672`: RabbitMQ AMQP
 - [`localhost:15672`](http://localhost:15672): RabbitMQ management.
-  User is `blink`, password is `blink`.
+  Username: `blink`, password: `blink`.
 
 ## API Endpoints
 ### Core

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@
 2. Run `npm start` to start Express.js app
 
 ## Usage
-- Launch RabbitMQ: `docker-compose up`
+- Launch RabbitMQ `docker-compose up`
 - `npm start`
 - Open `http://localhost:5050`
 
 #### Available services
 - `localhost:5672`: RabbitMQ AMQP
 - [`localhost:15672`](http://localhost:15672): RabbitMQ management.
-  User and password are `dosomething`.
+  User is `blink`, password is `blink`.
 
 ## API Endpoints
 ### Core

--- a/README.md
+++ b/README.md
@@ -3,17 +3,25 @@
 :postbox: The DoSomething.org Message Bus.
 
 ## Development
-### Requirements
+#### Requirements
 - [Node.js](https://nodejs.org/en/download/) v7.6+ for async/await support
+- [Docker](https://www.docker.com/products/overview) with support
+  of Compose file [v3](https://docs.docker.com/compose/compose-file/#/versioning)
 - [Yarn](https://yarnpkg.com/en/) is optional, but recommended
 
-### Installation
+#### Installation
 1. Install dependencies `yarn install` or `npm install`
 2. Run `npm start` to start Express.js app
 
 ## Usage
+- Launch RabbitMQ: `docker-compose up`
 - `npm start`
 - Open `http://localhost:5050`
+
+#### Available services
+- `localhost:5672`: RabbitMQ AMQP
+- [`localhost:15672`](http://localhost:15672): RabbitMQ management.
+  User and password are `dosomething`.
 
 ## API Endpoints
 ### Core
@@ -22,7 +30,6 @@
 | `GET /`                     | Greetings                   |
 | `GET /api`                  | List available API versions |
 | `GET /api/v1`               | List V1 endpoints           |
-
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 - [Yarn](https://yarnpkg.com/en/) is optional, but recommended
 
 #### Installation
-1. Install dependencies `yarn install` or `npm install`
-2. Run `npm start` to start Express.js app
+Install dependencies `yarn install` or `npm install`
 
 ## Usage
 - Launch RabbitMQ `docker-compose up`

--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ BDD test coverage uses the following utilities:
 - [AVA](https://github.com/avajs/ava)
 - [Chai](http://chaijs.com/), BDD/should flavor
 - [Supertest](https://github.com/visionmedia/supertest)
+
+#### Code coverage
+
+```
+$ npm run test-with-coverage
+```
+
+- [NYC](https://github.com/istanbul/nyc)
+- [Codecov](https://codecov.io/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+---
+version: '2'
+services:
+  rabbitmq:
+    image: rabbitmq:management
+    environment:
+      RABBITMQ_DEFAULT_USER: 'blink'
+      RABBITMQ_DEFAULT_VHOST: 'blink'
+      # Development password.
+      RABBITMQ_DEFAULT_PASS: 'blink'
+    ports:
+      - 15672:15672 # Management
+      - 5672:5672 # AMQP


### PR DESCRIPTION
#### What's this PR do?
- Adds simple RabbitMQ instance for local testing using Docker

#### How should this be manually tested?
- `docker compose up`
- [`localhost:15672`](http://localhost:15672): RabbitMQ management.
  Username: `blink`, password: `blink`.

#### What are the relevant tickets?
- Project [Blink MVP](https://github.com/DoSomething/blink/projects/1)
- A part of Trello ticket https://trello.com/c/P2iUMWYt/289-13-blink-version-1-0-setup-first-consumer