### PR TITLE
Replace axios with isomorphic fetch in RabbitManagement

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,9 @@
   extends: "@dosomething/eslint-config"
   env:
     es6: true
+  globals:
+    # Support fetch mechanism through isomorphic-fetch module
+    fetch: true
   parserOptions:
     # Node requires 'use strict' to use built-in ES6 compatibility.
     # Use script source type, so lint doesn't throw error:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:3.6.8-management
     environment:
       RABBITMQ_DEFAULT_USER: 'blink'
       RABBITMQ_DEFAULT_VHOST: 'blink'

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -34,12 +34,13 @@ class RabbitManagement {
 
   async getQueueBindings(queue) {
     const endpoint = `/bindings/${this.vhost}/e/${queue.exchange.name}/q/${queue.name}`;
-    const response = await this.get(endpoint);
-    // Response always returns 200 and valid JSON.
-    // Return false when not bindings found.
-    if (response.length < 1) {
-      return false;
+    try {
+      const response = await this.get(endpoint);
+    } catch (error) {
+      // Wrap HTTP exceptions in meaningful response.
+      throw new Error(`Incorrect RabbitManagement.getQueueBindings() response for GET ${endpoint}: ${error.message}`);
     }
+
     return response;
   }
 
@@ -52,7 +53,6 @@ class RabbitManagement {
 
   handleFetchResponse(response) {
     // Tolerate "200 OK" responses only.
-    console.dir(this.vhost, { colors: true, showHidden: true });
     if (response.status !== 200) {
       throw new Error(response.statusText);
     }

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -52,6 +52,7 @@ class RabbitManagement {
 
   handleFetchResponse(response) {
     // Tolerate "200 OK" responses only.
+    console.dir(this.vhost, { colors: true, showHidden: true });
     if (response.status !== 200) {
       throw new Error(response.statusText);
     }

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -10,7 +10,7 @@ class RabbitManagement {
       hostname,
       port,
       // Plugin rabbitmq_management API always lives under /api/
-      pathname: '/api/',
+      pathname: '/api',
     });
 
     // Create basic auth header.
@@ -34,21 +34,20 @@ class RabbitManagement {
 
   async getQueueBindings(queue) {
     const endpoint = `/bindings/${this.vhost}/e/${queue.exchange.name}/q/${queue.name}`;
-    try {
-      const response = await this.get(endpoint);
-    } catch (error) {
-      // Wrap HTTP exceptions in meaningful response.
-      throw new Error(`Incorrect RabbitManagement.getQueueBindings() response for GET ${endpoint}: ${error.message}`);
+    const response = await this.get(endpoint);
+    // Response always returns 200 and valid JSON.
+    // Return false when not bindings found.
+    if (response.length < 1) {
+      return false;
     }
-
     return response;
   }
 
   async get(endpoint) {
     const options = this.getFetchDefaults();
-    const response = await fetch(this.fullUri(endpoint), options);
-    const data = this.handleFetchResponse(response);
-    return data;
+    const fullUrl = this.fullUri(endpoint);
+    const response = await fetch(fullUrl, options);
+    return this.handleFetchResponse(response);
   }
 
   handleFetchResponse(response) {

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -53,7 +53,7 @@ class RabbitManagement {
   handleFetchResponse(response) {
     // Tolerate "200 OK" responses only.
     if (response.status !== 200) {
-      throw new Error(response.statusText);
+      throw new Error(`RabbitManagement.handleFetchResponse(): HTTP status ${response.status}: ${response.statusText}`);
     }
 
     // Always expect correct 200 response to have JSON body.

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const axios = require('axios');
+require('isomorphic-fetch');
 const URL = require('url');
-
 
 class RabbitManagement {
   constructor({ protocol, hostname, port, username, password, vhost }) {
-    const baseURL = URL.format({
+    this.baseURL = URL.format({
       protocol,
       hostname,
       port,
@@ -14,18 +13,10 @@ class RabbitManagement {
       pathname: '/api/',
     });
 
-    // Setup HTTP agent.
-    this.client = axios.create({
-      baseURL,
-      auth: {
-        username,
-        password,
-      },
-      maxRedirects: 0,
-      validateStatus: status => status === 200,
-    });
+    // Create basic auth header.
+    this.authHeader = Buffer(`${username}:${password}`).toString('base64');
 
-    // Setup amqp settings.
+    // Expose AMQP vhost for generating correct endpoints.
     this.vhost = vhost;
   }
 
@@ -33,23 +24,51 @@ class RabbitManagement {
     const endpoint = `/queues/${this.vhost}/${queue.name}`;
     let response = {};
     try {
-      response = await this.client.get(endpoint);
+      response = await this.get(endpoint);
     } catch (error) {
       // Wrap HTTP exceptions in meaningful response.
       throw new Error(`Incorrect RabbitManagement.getQueueInfo() response for GET ${endpoint}: ${error.message}`);
     }
-    return response.data;
+    return response;
   }
 
   async getQueueBindings(queue) {
     const endpoint = `/bindings/${this.vhost}/e/${queue.exchange.name}/q/${queue.name}`;
-    const response = await this.client.get(endpoint);
-    // Response always returns 200 and valid json.
+    const response = await this.get(endpoint);
+    // Response always returns 200 and valid JSON.
     // Return false when not bindings found.
-    if (response.data.length < 1) {
+    if (response.length < 1) {
       return false;
     }
-    return response.data;
+    return response;
+  }
+
+  async get(endpoint) {
+    const options = this.getFetchDefaults();
+    const response = await fetch(this.fullUri(endpoint), options);
+    return RabbitManagement.handleFetchResponse(response);
+  }
+
+  static handleFetchResponse(response) {
+    // Tolerate "200 OK" responses only.
+    if (response.status !== 200) {
+      throw new Error(response.statusText);
+    }
+
+    // Always expect correct 200 response to have JSON body.
+    return response.json();
+  }
+
+  fullUri(endpoint) {
+    return `${this.baseURL}${endpoint}`;
+  }
+
+  getFetchDefaults() {
+    return {
+      headers: {
+        Authorization: `Basic ${this.authHeader}`,
+      },
+    };
   }
 }
 

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -16,7 +16,7 @@ class RabbitManagement {
     // Create basic auth header.
     this.authHeader = Buffer(`${username}:${password}`).toString('base64');
 
-    // Expose AMQP vhost for generating correct endpoints.
+    // Expose AMQP vhost for building correct API endpoints.
     this.vhost = vhost;
   }
 

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -35,9 +35,10 @@ class RabbitManagement {
   async getQueueBindings(queue) {
     const endpoint = `/bindings/${this.vhost}/e/${queue.exchange.name}/q/${queue.name}`;
     const response = await this.get(endpoint);
-    // Response always returns 200 and valid JSON.
-    // Return false when not bindings found.
+    // API returns 200 and empty array when no bindings found.
     if (response.length < 1) {
+      // Return false if queue is not bound to its exchange:
+      // by design of this app a queue should have at least one valid route.
       return false;
     }
     return response;

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -46,10 +46,11 @@ class RabbitManagement {
   async get(endpoint) {
     const options = this.getFetchDefaults();
     const response = await fetch(this.fullUri(endpoint), options);
-    return RabbitManagement.handleFetchResponse(response);
+    const data = this.handleFetchResponse(response);
+    return data;
   }
 
-  static handleFetchResponse(response) {
+  handleFetchResponse(response) {
     // Tolerate "200 OK" responses only.
     if (response.status !== 200) {
       throw new Error(response.statusText);

--- a/lib/RabbitManagement.js
+++ b/lib/RabbitManagement.js
@@ -47,10 +47,10 @@ class RabbitManagement {
     const options = this.getFetchDefaults();
     const fullUrl = this.fullUri(endpoint);
     const response = await fetch(fullUrl, options);
-    return this.handleFetchResponse(response);
+    return RabbitManagement.handleFetchResponse(response);
   }
 
-  handleFetchResponse(response) {
+  static handleFetchResponse(response) {
     // Tolerate "200 OK" responses only.
     if (response.status !== 200) {
       throw new Error(`RabbitManagement.handleFetchResponse(): HTTP status ${response.status}: ${response.statusText}`);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
-    "node": ">=7.6.0"
+    "node": ">=7.7.3"
   },
   "scripts": {
     "test": "NODE_ENV=test ava",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
-    "node": ">=7.7.3"
+    "node": ">=7.7.4"
   },
   "scripts": {
     "test": "NODE_ENV=test ava",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "amqp-uri": "^2.0.0",
     "amqplib": "^0.5.1",
-    "axios": "^0.15.3",
     "change-case": "^3.0.1",
     "express": "^4.15.2",
+    "isomorphic-fetch": "^2.2.1",
     "nyc": "^10.1.2",
     "winston": "^2.3.1"
   },

--- a/test/lib/RabbitManagement.test.js
+++ b/test/lib/RabbitManagement.test.js
@@ -46,8 +46,8 @@ test('RabbitManagement.getQueueInfo(): Test Queue not found response', async () 
   const rabbit = new RabbitManagement(locals.amqpManagement);
 
   // Test request to fail.
-  const failedgetQueueInfo = rabbit.getQueueInfo(notInitializedQ);
-  await failedgetQueueInfo.should.be.rejectedWith(
+  const failedGetQueueInfo = rabbit.getQueueInfo(notInitializedQ);
+  await failedGetQueueInfo.should.be.rejectedWith(
     Error,
     'Incorrect RabbitManagement.getQueueInfo() response for GET /queues/blink/not-initialized'
   );
@@ -75,7 +75,10 @@ test('RabbitManagement.getQueueBindings(): Test response for not bound queues', 
   const rabbit = new RabbitManagement(locals.amqpManagement);
 
   // Test request to return 0 bindings.
-  const bindings = await rabbit.getQueueBindings(notBoundQ);
-  bindings.should.be.false;
+  const failedGetQueueBindings =  rabbit.getQueueBindings(notBoundQ);
+  await failedGetQueueBindings.should.be.rejectedWith(
+    Error,
+    'Incorrect RabbitManagement.getQueueBindings() response for GET /bindings/blink/e/test-x/q/not-bound'
+  );
 });
 

--- a/test/lib/RabbitManagement.test.js
+++ b/test/lib/RabbitManagement.test.js
@@ -75,10 +75,7 @@ test('RabbitManagement.getQueueBindings(): Test response for not bound queues', 
   const rabbit = new RabbitManagement(locals.amqpManagement);
 
   // Test request to return 0 bindings.
-  const failedGetQueueBindings =  rabbit.getQueueBindings(notBoundQ);
-  await failedGetQueueBindings.should.be.rejectedWith(
-    Error,
-    'Incorrect RabbitManagement.getQueueBindings() response for GET /bindings/blink/e/test-x/q/not-bound'
-  );
+  const bindings = await rabbit.getQueueBindings(notBoundQ);
+  bindings.should.be.false;
 });
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: node:7.7.1
+box: node:7.7.4
 services:
   - id: rabbitmq:management
     env:

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,6 @@
 box: node:7.7.4
 services:
-  - id: rabbitmq:management
+  - id: rabbitmq:3.6.8-management
     env:
       RABBITMQ_DEFAULT_USER: $BLINK_AMQP_USER
       RABBITMQ_DEFAULT_PASS: $BLINK_AMQP_PASSWORD

--- a/wercker.yml
+++ b/wercker.yml
@@ -7,7 +7,15 @@ services:
       RABBITMQ_DEFAULT_VHOST: $BLINK_AMQP_VHOST
 build:
   steps:
-    - npm-install
+    - script:
+      name: install yarn
+      code: npm install -g yarn
+    - script:
+      name: set yarn cache
+      code: export YARN_CACHE=$WERCKER_CACHE_DIR/yarn
+    - script:
+      name: install dependencies
+      code: HOME=$YARN_CACHE yarn
     - script:
         name: link RabbitMQ service
         code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,9 +8,6 @@ services:
 build:
   steps:
     - script:
-      name: install yarn
-      code: npm install -g yarn
-    - script:
       name: set yarn cache
       code: export YARN_CACHE=$WERCKER_CACHE_DIR/yarn
     - script:

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,12 +361,6 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-axios@^0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
-  dependencies:
-    follow-redirects "1.0.0"
-
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -1289,6 +1283,12 @@ encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 enhance-visitors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a"
@@ -1733,12 +1733,6 @@ fn-name@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
-follow-redirects@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
-  dependencies:
-    debug "^2.2.0"
-
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2044,6 +2038,10 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+iconv-lite@~0.4.13:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
+
 ignore-by-default@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -2302,7 +2300,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2345,6 +2343,13 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
@@ -2801,6 +2806,13 @@ no-case@^2.2.0:
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@^1.0.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-pre-gyp@^0.6.29:
   version "0.6.33"
@@ -4065,6 +4077,10 @@ verror@1.3.6:
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### What's this PR do?
- In order to standartize DoSomething toolset this PR replaces [axios](https://github.com/mzabriskie/axios) HTTP client library with [isomorphic fetch](https://github.com/matthew-andrews/isomorphic-fetch) in RabbitManagement
- Makes wercker install packages through `yarn`
- Fixes [`rabbitmq-management`](https://hub.docker.com/_/rabbitmq/) version to 3.6.8

#### How should this be manually tested?
- `yarn install`
- `npm run all-tests`

#### What are the relevant tickets?
Fixes #12.
