### PR TITLE
Omit port 80 in base uri

### DIFF
--- a/config/env/override-test.js
+++ b/config/env/override-test.js
@@ -12,7 +12,7 @@ module.exports = (config) => {
   // Randomize port for test runner.
   // Port 0 means random port:
   // https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback
-  config.web.port = 0;
+  config.web.bind_port = 0;
 
   // Test exchange name.
   // TODO: Randomize exchange name.

--- a/config/web.js
+++ b/config/web.js
@@ -4,13 +4,15 @@ const config = {};
 
 // Server bind port settings.
 // In addition, defaults to PORT env variable for compatibility with heroku.
-config.port = process.env.BLINK_WEB_PORT || process.env.PORT || 5050;
+config.bind_port = process.env.BLINK_WEB_BIND_PORT || process.env.PORT || 5050;
 // Server bind IP address setting.
 // When ommited, dafaults to :: or 0.0.0.0 based on ip setting.
 config.bind_address = process.env.BLINK_WEB_BIND_ADDRESS || '';
-// Base URI.
+// Base URI
 config.hostname = process.env.BLINK_WEB_HOSTNAME || 'localhost';
-// Http protocol
+// Base URI port
+config.port = process.env.BLINK_WEB_PORT || config.bind_port || 80;
+// Base URI protocol
 config.protocol = process.env.BLINK_WEB_PROTOCOL || 'http';
 
 module.exports = config;

--- a/lib/WebController.js
+++ b/lib/WebController.js
@@ -15,10 +15,11 @@ class WebController {
    * @return {String}      Full route URL
    */
   fullUrl(name) {
+    const port = this.web.port !== 80 ? this.web.port : null;
     return URL.format({
       protocol: this.web.protocol,
       hostname: this.web.hostname,
-      port: this.web.port,
+      port: port,
       pathname: this.router.url(name),
     });
   }

--- a/lib/WebController.js
+++ b/lib/WebController.js
@@ -19,7 +19,7 @@ class WebController {
     return URL.format({
       protocol: this.web.protocol,
       hostname: this.web.hostname,
-      port: port,
+      port,
       pathname: this.router.url(name),
     });
   }

--- a/test/lib/WebController.test.js
+++ b/test/lib/WebController.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const chai = require('chai');
+const Router = require('koa-router');
+const test = require('ava');
+const WebController = require('../../lib/WebController');
+
+
+// Chai setup.
+chai.should();
+
+/**
+ * WebController class interface
+ */
+test('WebController interface', () => {
+  const config = require('../../config');
+  const web = new WebController(config);
+  web.should.have.respondTo('fullUrl');
+});
+
+/**
+ * WebController.fullUrl(): Test generating urls for controller methods
+ */
+test('WebController.fullUrl(): Test generating urls for controller methods', () => {
+  class TestController extends WebController {
+    constructor(...args) {
+      super(...args);
+      this.index = this.index.bind(this);
+    }
+
+    index() {
+      this.logger.info('should not be called');
+    }
+  }
+
+  const config = require('../../config');
+  const router = new Router();
+  config.router = router;
+
+  // Expected port
+  config.web.port = 81;
+
+  const testController = new TestController(config);
+  router.get('test.route', '/test', testController.index);
+  testController.fullUrl('test.route').should.be.equal('http://localhost:81/test');
+});
+
+/**
+ * WebController.fullUrl(): Test ommitting port 80
+ */
+test('WebController.fullUrl(): Test ommitting port 80', () => {
+  class TestController extends WebController {
+    constructor(...args) {
+      super(...args);
+      this.index = this.index.bind(this);
+    }
+
+    index() {
+      this.logger.info('should not be called');
+    }
+  }
+
+  const config = require('../../config');
+  const router = new Router();
+  config.router = router;
+
+  // Expected port
+  config.web.port = 80;
+
+  const testController = new TestController(config);
+  router.get('test.route', '/test', testController.index);
+  testController.fullUrl('test.route').should.be.equal('http://localhost/test');
+});

--- a/web/blinkWeb.js
+++ b/web/blinkWeb.js
@@ -50,7 +50,7 @@ server.listen(config.web.bind_port, config.web.bind_address, () => {
   // Make sure random port setting gets overriden with actual resolved port.
   config.web.bind_port = address.port;
   config.logger.info(
-    `Blink is listening on http://${config.web.hostname}:${config.web.port} env:${config.app.env}`
+    `Blink is listening on http://${config.web.hostname}:${config.web.bind_port} env:${config.app.env}`
   );
 });
 

--- a/web/blinkWeb.js
+++ b/web/blinkWeb.js
@@ -45,10 +45,10 @@ blinkWeb
  * Create server.
  */
 const server = http.createServer(blinkWeb.callback());
-server.listen(config.web.port, config.web.bind_address, () => {
+server.listen(config.web.bind_port, config.web.bind_address, () => {
   const address = server.address();
   // Make sure random port setting gets overriden with actual resolved port.
-  config.web.port = address.port;
+  config.web.bind_port = address.port;
   config.logger.info(
     `Blink is listening on http://${config.web.hostname}:${config.web.port} env:${config.app.env}`
   );


### PR DESCRIPTION
Minor:
- differentiate between http server bind port and front-facing port (base URI port)
- omit port 80 in web URIs
- add test coverage for `WebController.fullUrl()`