### PR TITLE
Make sure WebController.fullUrl() accepts port from env var

### DIFF
--- a/lib/WebController.js
+++ b/lib/WebController.js
@@ -15,7 +15,11 @@ class WebController {
    * @return {String}      Full route URL
    */
   fullUrl(name) {
-    const port = this.web.port !== 80 ? this.web.port : null;
+    let port = parseInt(this.web.port, 10);
+    if (port === 80) {
+      // Omit port 80 in URLs.
+      port = null;
+    }
     return URL.format({
       protocol: this.web.protocol,
       hostname: this.web.hostname,

--- a/test/lib/WebController.test.js
+++ b/test/lib/WebController.test.js
@@ -68,7 +68,7 @@ test('WebController.fullUrl(): Test ommitting port 80', () => {
   config.router = router;
 
   // Expected port
-  config.web.port = 80;
+  config.web.port = '80';
 
   const testController = new TestController(config);
   router.get('test.route', '/test', testController.index);


### PR DESCRIPTION
Minor: Fix mistake made in #19. The function wasn't recognizing port 80 when it's set through env variables, because env vars are passed as strings.