### PR TITLE
[#143258643] Implements Mobile Commons / Gambit Chatbot queue

### DIFF
--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -6,6 +6,7 @@ const logger = require('winston');
 const Exchange = require('../lib/Exchange');
 const CustomerIoWebhookQ = require('../queues/CustomerIoWebhookQ');
 const FetchQ = require('../queues/FetchQ');
+const GambitChatbotMdataQ = require('../queues/GambitChatbotMdataQ');
 
 class BlinkApp {
   constructor(config) {
@@ -40,6 +41,7 @@ class BlinkApp {
       this.queues = await this.setupQueues([
         CustomerIoWebhookQ,
         FetchQ,
+        GambitChatbotMdataQ,
       ]);
     } catch (error) {
       this.connecting = false;

--- a/src/queues/GambitChatbotMdataQ.js
+++ b/src/queues/GambitChatbotMdataQ.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('isomorphic-fetch');
+
+const MdataMessage = require('../messages/MdataMessage');
+const Queue = require('./Queue');
+
+class GambitChatbotMdataQ extends Queue {
+
+  constructor(...args) {
+    super(...args);
+    this.messageClass = MdataMessage;
+  }
+
+}
+
+module.exports = GambitChatbotMdataQ;

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -37,6 +37,8 @@ class WebHooksWebController extends WebController {
     try {
       const mdataMessage = MdataMessage.fromCtx(ctx);
       mdataMessage.validate();
+      const { gambitChatbotMdataQ } = this.blink.queues;
+      gambitChatbotMdataQ.publish(mdataMessage);
     } catch (error) {
       this.sendError(ctx, error);
       return;


### PR DESCRIPTION
#### What's this PR do?
- Saves data from `/api/v1/webhooks/gambit-chatbot-mdata` to GambitChatbotMdataQ

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
- `yarn web`

#### Next up
- Load test data ingestion
- Concurrency for web process using throng
- Gambit Chatbot Mdata worker
- QOS for Gambit Chatbot Mdata worker
- Retry in Gambit Chatbot Mdata

#### What are the relevant tickets?
Pivotal [143258643](https://www.pivotaltracker.com/story/show/143258643)
