### PR TITLE
Fix code coverage report: include all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "NODE_ENV=test ava",
     "lint": "eslint .",
-    "coverage": "NODE_ENV=test nyc ava",
+    "coverage": "NODE_ENV=test nyc --all ava",
     "all-tests": "npm run lint && npm run coverage",
     "html-coverage-report": "nyc report --reporter=html",
     "publish-coverage-report": "nyc report --reporter=lcov && codecov",
@@ -58,6 +58,7 @@
   "nyc": {
     "exclude": [
       "config",
+      "coverage",
       "test"
     ]
   }


### PR DESCRIPTION
This makes coverage report more truthful by including all files.
Turned out default `nyc` behavior is to include only explicitly required files. 