### PR TITLE
[#142860245] Rename customer.io email activity webhook and send it to quasar queue

### DIFF
--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -4,9 +4,9 @@ const changeCase = require('change-case');
 const logger = require('winston');
 
 const Exchange = require('../lib/Exchange');
-const CustomerIoWebhookQ = require('../queues/CustomerIoWebhookQ');
 const FetchQ = require('../queues/FetchQ');
 const GambitChatbotMdataQ = require('../queues/GambitChatbotMdataQ');
+const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
 
 class BlinkApp {
   constructor(config) {
@@ -39,7 +39,7 @@ class BlinkApp {
 
       // Initialize and setup all available queues.
       this.queues = await this.setupQueues([
-        CustomerIoWebhookQ,
+        QuasarCustomerIoEmailActivityQ,
         FetchQ,
         GambitChatbotMdataQ,
       ]);

--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -53,9 +53,9 @@ class BlinkWebApp extends BlinkApp {
     // Webhooks
     router.get('api.v1.webhooks', '/api/v1/webhooks', webHooksWebController.index);
     router.post(
-      'api.v1.webhooks.customerio',
-      '/api/v1/webhooks/customerio',
-      webHooksWebController.customerio
+      'api.v1.webhooks.customerio-email-activity',
+      '/api/v1/webhooks/customerio-email-activity',
+      webHooksWebController.customerioEmailActivity
     );
     router.post(
       'api.v1.webhooks.gambit-chatbot-mdata',

--- a/src/queues/CustomerIoWebhookQ.js
+++ b/src/queues/CustomerIoWebhookQ.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const Queue = require('./Queue');
-
-class CustomerIoWebhookQ extends Queue {
-
-}
-
-module.exports = CustomerIoWebhookQ;

--- a/src/queues/QuasarCustomerIoEmailActivityQ.js
+++ b/src/queues/QuasarCustomerIoEmailActivityQ.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const Queue = require('./Queue');
+
+class QuasarCustomerIoEmailActivityQ extends Queue {
+
+}
+
+module.exports = QuasarCustomerIoEmailActivityQ;

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -9,23 +9,23 @@ class WebHooksWebController extends WebController {
     super(...args);
     // Bind web methods to object context so they can be passed to router.
     this.index = this.index.bind(this);
-    this.customerio = this.customerio.bind(this);
+    this.customerioEmailActivity = this.customerioEmailActivity.bind(this);
     this.gambitChatbotMdata = this.gambitChatbotMdata.bind(this);
   }
 
   async index(ctx) {
     ctx.body = {
-      customerio: this.fullUrl('api.v1.webhooks.customerio'),
+      'customerio-email-activity': this.fullUrl('api.v1.webhooks.customerio-email-activity'),
       'gambit-chatbot-mdata': this.fullUrl('api.v1.webhooks.gambit-chatbot-mdata'),
     };
   }
 
-  async customerio(ctx) {
+  async customerioEmailActivity(ctx) {
     try {
       const customerIoWebhookMessage = CustomerIoWebhookMessage.fromCtx(ctx);
       customerIoWebhookMessage.validate();
-      const { customerIoWebhookQ } = this.blink.queues;
-      customerIoWebhookQ.publish(customerIoWebhookMessage);
+      const { quasarCustomerIoEmailActivityQ } = this.blink.queues;
+      quasarCustomerIoEmailActivityQ.publish(customerIoWebhookMessage);
     } catch (error) {
       this.sendError(ctx, error);
       return;

--- a/test/queues/CustomerIoWebhookQ.test.js
+++ b/test/queues/CustomerIoWebhookQ.test.js
@@ -6,13 +6,13 @@
 const test = require('ava');
 require('chai').should();
 
-const CustomerIoWebhookQ = require('../../src/queues/CustomerIoWebhookQ');
+const QuasarCustomerIoEmailActivityQ = require('../../src/queues/QuasarCustomerIoEmailActivityQ');
 const Queue = require('../../src/queues/Queue');
 
 /**
- * Test CustomerIoWebhookQ class
+ * Test QuasarCustomerIoEmailActivityQ class
  */
-test.skip('CustomerIoWebhookQ', () => {
-  const customerIoWebhookQ = new CustomerIoWebhookQ();
+test.skip('QuasarCustomerIoEmailActivityQ', () => {
+  const customerIoWebhookQ = new QuasarCustomerIoEmailActivityQ();
   customerIoWebhookQ.should.be.an.instanceof(Queue);
 });

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -30,8 +30,8 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
   res.header['content-type'].should.match(/json/);
 
   // Check response.
-  res.body.should.have.property('customerio')
-    .and.have.string('/api/v1/webhooks/customerio');
+  res.body.should.have.property('customerio-email-activity')
+    .and.have.string('/api/v1/webhooks/customerio-email-activity');
   res.body.should.have.property('gambit-chatbot-mdata')
     .and.have.string('/api/v1/webhooks/gambit-chatbot-mdata');
 });
@@ -39,7 +39,7 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
 /**
  * POST /api/v1/webhooks/customerio
  */
-test('POST /api/v1/webhooks/customerio should publish message to customer-io queue', async (t) => {
+test('POST /api/v1/webhooks/customerio-email-activity should publish message to customer-io queue', async (t) => {
   const data = {
     data: {
       campaign_id: '0',
@@ -54,7 +54,7 @@ test('POST /api/v1/webhooks/customerio should publish message to customer-io que
     timestamp: 1491337360,
   };
 
-  const res = await t.context.supertest.post('/api/v1/webhooks/customerio')
+  const res = await t.context.supertest.post('/api/v1/webhooks/customerio-email-activity')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send(data);
 
@@ -70,7 +70,7 @@ test('POST /api/v1/webhooks/customerio should publish message to customer-io que
   // Check that the message is queued.
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);
   // TODO: queue cleanup to make sure that it's not OLD message.
-  const messages = await rabbit.getMessagesFrom('customer-io-webhook', 1);
+  const messages = await rabbit.getMessagesFrom('quasar-customer-io-email-activity', 1);
   messages.should.be.an('array').and.to.have.lengthOf(1);
 
   messages[0].should.have.property('payload');


### PR DESCRIPTION
#### What's this PR do?
- Renames Customer.io email activity integration endpoint from `/api/v1/webhooks/customerio-webhook` to `/api/v1/webhooks/customerio-email-activity`
- Renames `CustomerIoWebhookQ` to `QuasarCustomerIoEmailActivityQ` classes to delegate this queue to Quasar.

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
- `yarn web`

#### What are the relevant tickets?
Pivotal [142860245](https://www.pivotaltracker.com/story/show/142860245)
