### PR TITLE
[#143443281] Blink web concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "koa-bodyparser": "^4.2.0",
     "koa-router": "^7.1.1",
     "newrelic": "^1.38.2",
+    "throng": "^4.0.0",
     "uuid": "^3.0.1",
     "winston": "^2.3.1",
     "yargs": "^7.1.0"

--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -16,9 +16,10 @@ class BlinkApp {
     this.connected = false;
     this.connecting = false;
     this.shuttingDown = false;
-
-    // Attach reconnect function to object context.
     this.reconnectTimeout = 2000;
+
+    // Attach functions to object context.
+    this.start = this.start.bind(this);
     this.reconnect = this.reconnect.bind(this);
   }
 

--- a/start.js
+++ b/start.js
@@ -34,7 +34,7 @@ switch (command) {
     concurrency = process.env.BLINK_CONCURRENCY_WEB;
     throng({
       workers: concurrency || 1,
-      // TODO: set not infinite lifetime and grace shutdown period
+      // TODO: set finite lifetime and grace shutdown period
       lifetime: Infinity,
       start: () => {
         blinkApp = new BlinkWebApp(config);

--- a/start.js
+++ b/start.js
@@ -34,10 +34,12 @@ switch (command) {
     concurrency = process.env.BLINK_CONCURRENCY_WEB;
     throng({
       workers: concurrency || 1,
+      // TODO: set not infinite lifetime and grace shutdown period
       lifetime: Infinity,
       start: () => {
         blinkApp = new BlinkWebApp(config);
         blinkApp.start();
+        // TODO: prepare shutdown.
       }
     });
     break;

--- a/start.js
+++ b/start.js
@@ -42,6 +42,7 @@ switch (command) {
     });
     break;
   case 'worker':
+    // TODO:  Workers concurrency.
     blinkApp = new BlinkWorkerApp(config, argv.name);
     blinkApp.start();
     break;

--- a/start.js
+++ b/start.js
@@ -27,6 +27,7 @@ const argv = yargs
 
 let blinkApp;
 let concurrency;
+let workerConcurrencyEnvVar;
 const [command] = argv._;
 switch (command) {
   case 'web':
@@ -34,7 +35,7 @@ switch (command) {
     blinkApp = new BlinkWebApp(config);
     break;
   case 'worker':
-    const workerConcurrencyEnvVar = `BLINK_CONCURRENCY_WORKER_${argv.name.toUpperCase()}`;
+    workerConcurrencyEnvVar = `BLINK_CONCURRENCY_WORKER_${argv.name.toUpperCase()}`;
     concurrency = process.env[workerConcurrencyEnvVar];
     blinkApp = new BlinkWorkerApp(config, argv.name);
     break;

--- a/start.js
+++ b/start.js
@@ -27,7 +27,6 @@ const argv = yargs
 
 let blinkApp;
 let concurrency;
-let workerConcurrencyEnvVar;
 const [command] = argv._;
 switch (command) {
   case 'web':
@@ -40,7 +39,7 @@ switch (command) {
         blinkApp = new BlinkWebApp(config);
         blinkApp.start();
         // TODO: prepare shutdown.
-      }
+      },
     });
     break;
   case 'worker':

--- a/start.js
+++ b/start.js
@@ -32,21 +32,22 @@ const [command] = argv._;
 switch (command) {
   case 'web':
     concurrency = process.env.BLINK_CONCURRENCY_WEB;
-    blinkApp = new BlinkWebApp(config);
+    throng({
+      workers: concurrency || 1,
+      lifetime: Infinity,
+      start: () => {
+        blinkApp = new BlinkWebApp(config);
+        blinkApp.start();
+      }
+    });
     break;
   case 'worker':
-    workerConcurrencyEnvVar = `BLINK_CONCURRENCY_WORKER_${argv.name.toUpperCase()}`;
-    concurrency = process.env[workerConcurrencyEnvVar];
     blinkApp = new BlinkWorkerApp(config, argv.name);
+    blinkApp.start();
     break;
   default:
     throw new Error('Argument parsing integrity violation');
 }
 
-throng({
-  workers: concurrency || 1,
-  lifetime: Infinity,
-  start: blinkApp.start,
-});
 
 // ------- End -----------------------------------------------------------------

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,6 +2792,10 @@ lodash.debounce@^4.0.3:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
 lodash.difference@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
@@ -4097,6 +4101,12 @@ test-exclude@^4.0.0:
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+throng@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/throng/-/throng-4.0.0.tgz#983c6ba1993b58eae859998aa687ffe88df84c17"
+  dependencies:
+    lodash.defaults "^4.0.1"
 
 through2@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
#### What's this PR do?
- Utilizes [`throng`](https://github.com/hunterloftis/throng) to spawn web cluster

#### How should this be manually tested?
- `BLINK_CONCURRENCY_WEB=10 node start.js web`

#### Any background context you want to provide?
1 standard heroku dyno has 512 Mb of memory. Web process that publishes to rabbit only consumes 110-120 Mb on the peak of load. Makes sense to utilize more memory. Running web cluster of 3 web workers per process is very safe way to increase Blink effectives.
See load test results here: https://docs.google.com/a/dosomething.org/spreadsheets/d/16MTMqV1rouex7_Y8wnt8OuRczs07rBSCCwVuO2Ir1J4/edit?usp=sharing

#### What are the relevant tickets?
Pivotal [143443281](https://www.pivotaltracker.com/story/show/143443281)