### PR TITLE
[#143258643] Basic Gambit proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # Disale New Relic locally
 NEW_RELIC_NO_CONFIG_FILE=true
 NEW_RELIC_ENABLED=false
+
+# Gambit
+GAMBIT_API_BASE_URL=http://localhost:5000/v1
+GAMBIT_API_KEY=totallysecret

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: npm run web
 fetch: npm run worker fetch
+gambit-chatbot-mdata-proxy: npm run worker gambit-chatbot-mdata-proxy

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -1,8 +1,6 @@
 
 'use strict';
 
-const packageJson = require('../package.json');
-
 const config = {
   baseUrl: process.env.GAMBIT_API_BASE_URL || 'http://localhost:5000/v1',
   apiKey: process.env.GAMBIT_API_KEY || 'totallysecret',

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -1,0 +1,11 @@
+
+'use strict';
+
+const packageJson = require('../package.json');
+
+const config = {
+  baseUrl: process.env.GAMBIT_API_BASE_URL || 'http://localhost:5000/v1',
+  apiKey: process.env.GAMBIT_API_KEY || 'totallysecret',
+};
+
+module.exports = config;

--- a/config/index.js
+++ b/config/index.js
@@ -13,6 +13,7 @@ config.app = require('./app');
 config.web = require('./web');
 config.amqp = require('./amqp');
 config.amqpManagement = require('./amqpManagement');
+config.gambit = require('./gambit');
 
 // Require env-dependent configs
 const envConfigPath = `${__dirname}/env/override-${config.app.env}.js`;

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -2,6 +2,7 @@
 
 const BlinkError = require('../errors/BlinkError');
 const FetchWorker = require('../workers/FetchWorker');
+const GambitChatbotMdataProxyWorker = require('../workers/GambitChatbotMdataProxyWorker');
 const BlinkApp = require('./BlinkApp');
 
 class BlinkWorkerApp extends BlinkApp {
@@ -28,6 +29,7 @@ class BlinkWorkerApp extends BlinkApp {
   static getAvailableWorkers() {
     return {
       fetch: FetchWorker,
+      'gambit-chatbot-mdata-proxy': GambitChatbotMdataProxyWorker,
     };
   }
 }

--- a/src/workers/GambitChatbotMdataProxyWorker.js
+++ b/src/workers/GambitChatbotMdataProxyWorker.js
@@ -35,7 +35,8 @@ class GambitChatbotMdataProxyWorker extends Worker {
         },
         body: JSON.stringify(data),
       }
-    )
+    );
+
     if (response.status === 200) {
       this.log(
         'debug',

--- a/src/workers/GambitChatbotMdataProxyWorker.js
+++ b/src/workers/GambitChatbotMdataProxyWorker.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const logger = require('winston');
+
+const Worker = require('./Worker');
+
+class GambitChatbotMdataProxyWorker extends Worker {
+
+  constructor(blink) {
+    super(blink);
+    this.blink = blink;
+
+    this.gambitBaseUrl = this.blink.config.gambit.baseUrl;
+    this.gambitApiKey = this.blink.config.gambit.apiKey;
+
+    // Bind process method to queue context
+    this.consume = this.consume.bind(this);
+  }
+
+  setup() {
+    this.queue = this.blink.queues.gambitChatbotMdataQ;
+  }
+
+  async consume(mdataMessage) {
+    const data = mdataMessage.payload.data;
+    const url = `${this.gambitBaseUrl}/chatbot`;
+    const response = await fetch(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          'x-gambit-api-key': this.gambitApiKey,
+          'Content-type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      }
+    )
+    if (response.status === 200) {
+      this.log(
+        'debug',
+        mdataMessage,
+        response,
+        'success_fetch_response_200'
+      );
+      return true;
+    }
+
+    // Todo: retry when 500?
+    this.log(
+      'warning',
+      mdataMessage,
+      response,
+      'error_fetch_response_not_200'
+    );
+    return false;
+  }
+
+  async log(level, message, response, code = 'unexpected_code') {
+    const cleanedBody = (await response.text()).replace(/\n/g, '\\n');
+
+    const meta = {
+      // Todo: log env
+      code,
+      worker: this.constructor.name,
+      request_id: message ? message.payload.meta.request_id : 'not_parsed',
+      response_status: response.status,
+      response_status_text: `"${response.statusText}"`,
+    };
+    // Todo: log error?
+
+    logger.log(level, cleanedBody, meta);
+  }
+}
+
+module.exports = GambitChatbotMdataProxyWorker;

--- a/src/workers/GambitChatbotMdataProxyWorker.js
+++ b/src/workers/GambitChatbotMdataProxyWorker.js
@@ -30,6 +30,7 @@ class GambitChatbotMdataProxyWorker extends Worker {
         method: 'POST',
         headers: {
           'x-gambit-api-key': this.gambitApiKey,
+          'X-Request-ID': mdataMessage.payload.meta.request_id,
           'Content-type': 'application/json',
         },
         body: JSON.stringify(data),


### PR DESCRIPTION
#### What's this PR do?
- Consumes messages from `gambit-chatbot-mdata` queue and proxies them to gambit `/v1/chatbot`

#### How should this be manually tested?
- `yarn install`
- `yarn run all-tests`
- `yarn worker gambit-chatbot-mdata-proxy`
- `yarn web`
- `
curl -X "POST" "http://localhost:5050/api/v1/webhooks/gambit-chatbot-mdata" \
     -H "Content-Type: application/json" \
     -u blink:blink \
     -d $'{
  "keyword": "SHARE",
  "phone": "1<YOUR_PHONE>",
  "message_id": "841415468",
  "profile_id": "<YOUR MOCO ID>"
}'
`
- Or, just text `MIRRORBOT` to 38383

#### Next up
- QOS for Gambit Chatbot Mdata worker
- Retry in Gambit Chatbot Mdata

#### What are the relevant tickets?
Pivotal [143258643](https://www.pivotaltracker.com/story/show/143258643)
