### PR TITLE
[Finishes #143258643] Basic retry functionality

### DIFF
--- a/src/errors/BlinkRetryError.js
+++ b/src/errors/BlinkRetryError.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const BlinkError = require('./BlinkError');
+
+class BlinkRetryError extends BlinkError {
+  constructor(errorMessage, blinkMessage) {
+    super(errorMessage);
+    this.blinkMessage = blinkMessage;
+  }
+}
+
+module.exports = BlinkRetryError;

--- a/src/queues/Queue.js
+++ b/src/queues/Queue.js
@@ -48,12 +48,13 @@ class Queue {
     if (message.payload.meta.retry) {
       retry = message.payload.meta.retry;
     }
-    retry++;
-    message.payload.meta.retry = retry;
-    message.payload.meta.retryReason = reason;
+    retry += 1;
+    const retryMessage = message;
+    retryMessage.payload.meta.retry = retry;
+    retryMessage.payload.meta.retryReason = reason;
     // Republish modified message.
     this.nack(message);
-    this.publish(message);
+    this.publish(retryMessage);
   }
 
   /**

--- a/src/queues/Queue.js
+++ b/src/queues/Queue.js
@@ -88,7 +88,7 @@ class Queue {
         if (error instanceof BlinkRetryError) {
           // Todo: move to setting
           const retryTimeout = 2000;
-          const retryLimit = 3;
+          const retryLimit = 100;
           const retry = message.payload.meta.retry || 0;
           if (retry < retryLimit) {
             this.log(


### PR DESCRIPTION
#### What's this PR do?
- Implements basic message retry functionality
- Makes Blink retry requests to Gambit when it returns not 200 or 422

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
- `yarn web`
- `yarn worker gambit-chatbot-mdata-proxy`

#### Any background context you want to provide?
Current settings are to retry 100 times every 2 seconds, but that needs to be moved to env variables or pre-configured per consumer / queue.

#### What are the relevant tickets?
Pivotal [143258643](https://www.pivotaltracker.com/story/show/143258643)