### PR TITLE
Increase delay between retries

### DIFF
--- a/src/queues/Queue.js
+++ b/src/queues/Queue.js
@@ -87,19 +87,19 @@ class Queue {
       } catch (error) {
         if (error instanceof BlinkRetryError) {
           // Todo: move to setting
-          const retryTimeout = 2000;
           const retryLimit = 100;
           const retry = message.payload.meta.retry || 0;
+          const retryDelay = Queue.retryDelay(retry);
           if (retry < retryLimit) {
             this.log(
               'warning',
-              `Got error ${error}, retrying after ${retryTimeout}ms`,
+              `Got error ${error}, retry ${retry}, retrying after ${retryDelay}ms`,
               message,
               'error_got_retry_request'
             );
             setTimeout(() => {
               this.retry(error.toString(), message);
-            }, retryTimeout);
+            }, retryDelay);
           } else {
             this.log(
               'warning',
@@ -212,6 +212,12 @@ class Queue {
     };
 
     logger.log(level, logMessage, meta);
+  }
+
+  static retryDelay(currentRetryNumber) {
+    // Make longer delays as number of retries increases.
+    // https://docs.google.com/spreadsheets/d/1AECd5YrOXJnYlH7BW9wtPBL2Tqp5Wjd3c0VnYGqA780/edit?usp=sharing
+    return (Math.pow(currentRetryNumber, 2) / 4 + 1) * 1000;
   }
 
 }

--- a/src/queues/Queue.js
+++ b/src/queues/Queue.js
@@ -217,7 +217,8 @@ class Queue {
   static retryDelay(currentRetryNumber) {
     // Make longer delays as number of retries increases.
     // https://docs.google.com/spreadsheets/d/1AECd5YrOXJnYlH7BW9wtPBL2Tqp5Wjd3c0VnYGqA780/edit?usp=sharing
-    return (Math.pow(currentRetryNumber, 2) / 4 + 1) * 1000;
+    // eslint-disable-next-line no-mixed-operators
+    return ((currentRetryNumber ** 2) / 4 + 1) * 1000;
   }
 
 }

--- a/test/queues/Queue.test.js
+++ b/test/queues/Queue.test.js
@@ -126,3 +126,39 @@ test.skip('Queue.purge(): Ensure incorrect queue purging fails', async () => {
     'Queue.purge(): failed to purge queue "test-incorrect-purge"'
   );
 });
+
+
+/**
+ * Queue.purge(): Check retryDelay behavior
+ */
+test('Queue.retryDelay(): Check retryDelay behavior', async () => {
+  // First, delay between retries should be a matter of seconds
+  Queue.retryDelay(0).should.be.equal(1000);
+  Queue.retryDelay(1).should.be.equal(1250);
+  Queue.retryDelay(2).should.be.equal(2000);
+
+  // Delay should be between 20 and 30 sec on 10th retry.
+  Queue.retryDelay(10).should.be.above(20000).and.below(30000);
+
+  // Delay should be between 1 and 2 minutes on 20th retry.
+  Queue.retryDelay(20).should.be.above(1 * 60 * 1000).and.below(2 * 60 * 1000);
+
+  // Delay should be between 3 and 4 minutes on 30th retry.
+  Queue.retryDelay(30).should.be.above(3 * 60 * 1000).and.below(4 * 60 * 1000);
+
+  // Delay should be between 10 and 20 minutes on 50th retry.
+  Queue.retryDelay(50).should.be.above(10 * 60 * 1000).and.below(20 * 60 * 1000);
+
+  // Delay should be between 30 minutes and 1 hour on 100th retry.
+  Queue.retryDelay(100).should.be.above(30 * 60 * 1000).and.below(60 * 60 * 1000);
+
+  // Total wait time whould be less than a day.
+  let retry = 0;
+  let accumulator = 0;
+  while (retry <= 100) {
+    accumulator += Queue.retryDelay(retry);
+    retry += 1;
+  }
+  console.dir(accumulator, { colors: true, showHidden: true });
+  accumulator.should.be.below(60 * 60 * 1000 * 24);
+});

--- a/test/queues/Queue.test.js
+++ b/test/queues/Queue.test.js
@@ -131,7 +131,7 @@ test.skip('Queue.purge(): Ensure incorrect queue purging fails', async () => {
 /**
  * Queue.purge(): Check retryDelay behavior
  */
-test('Queue.retryDelay(): Check retryDelay behavior', async () => {
+test('Queue.retryDelay(): Check retryDelay behavior', () => {
   // First, delay between retries should be a matter of seconds
   Queue.retryDelay(0).should.be.equal(1000);
   Queue.retryDelay(1).should.be.equal(1250);
@@ -159,6 +159,5 @@ test('Queue.retryDelay(): Check retryDelay behavior', async () => {
     accumulator += Queue.retryDelay(retry);
     retry += 1;
   }
-  console.dir(accumulator, { colors: true, showHidden: true });
   accumulator.should.be.below(60 * 60 * 1000 * 24);
 });


### PR DESCRIPTION
#### What's this PR do?
- Gradually increases delay between unsuccessful message processing retries

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### Any background context you want to provide?
Blink retry chart: https://docs.google.com/spreadsheets/d/1AECd5YrOXJnYlH7BW9wtPBL2Tqp5Wjd3c0VnYGqA780/edit#gid=0
