### PR TITLE
[#143982623] Create basic user registration event endpoint

### DIFF
--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -8,12 +8,13 @@ const bodyParser = require('koa-bodyparser');
 const Router = require('koa-router');
 const logger = require('winston');
 
+const ApiWebController = require('../web/controllers/ApiWebController');
+const EventsWebController = require('../web/controllers/EventsWebController');
+const ToolsWebController = require('../web/controllers/ToolsWebController');
+const WebHooksWebController = require('../web/controllers/WebHooksWebController');
 const basicAuthCustom401 = require('../web/middleware/basicAuthCustom401');
 const generateRequestId = require('../web/middleware/generateRequestId');
 const BlinkApp = require('./BlinkApp');
-const ApiWebController = require('../web/controllers/ApiWebController');
-const ToolsWebController = require('../web/controllers/ToolsWebController');
-const WebHooksWebController = require('../web/controllers/WebHooksWebController');
 
 class BlinkWebApp extends BlinkApp {
   constructor(config) {
@@ -23,6 +24,7 @@ class BlinkWebApp extends BlinkApp {
     // Dynamically create and assign controllers.
     this.web.controllers = this.initControllers([
       ApiWebController,
+      EventsWebController,
       ToolsWebController,
       WebHooksWebController,
     ]);
@@ -40,6 +42,7 @@ class BlinkWebApp extends BlinkApp {
       apiWebController,
       toolsWebController,
       webHooksWebController,
+      eventsWebController,
     } = this.web.controllers;
 
     const router = new Router();
@@ -49,6 +52,14 @@ class BlinkWebApp extends BlinkApp {
     router.get('api.v1', '/api/v1', apiWebController.v1);
     router.get('api.v1.tools', '/api/v1/tools', toolsWebController.index);
     router.post('api.v1.tools.fetch', '/api/v1/tools/fetch', toolsWebController.fetch);
+
+    // Events
+    router.get('api.v1.events', '/api/v1/events', eventsWebController.index);
+    router.post(
+      'api.v1.events.user-registration',
+      '/api/v1/events/user-registration',
+      eventsWebController.userRegistration
+    );
 
     // Webhooks
     router.get('api.v1.webhooks', '/api/v1/webhooks', webHooksWebController.index);

--- a/src/messages/UserRegistrationMessage.js
+++ b/src/messages/UserRegistrationMessage.js
@@ -4,9 +4,6 @@ const Joi = require('joi');
 
 const Message = require('./Message');
 
-
-// TODO: url whitelist
-// TODO: authentication
 class UserRegistrationMessage extends Message {
 
   constructor(...args) {

--- a/src/messages/UserRegistrationMessage.js
+++ b/src/messages/UserRegistrationMessage.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const Joi = require('joi');
+
+const Message = require('./Message');
+
+
+// TODO: url whitelist
+// TODO: authentication
+class UserRegistrationMessage extends Message {
+
+  constructor(...args) {
+    super(...args);
+
+    // Data validation rules.
+    this.schema = Joi.object().keys({
+      id: Joi.string().regex(/^[0-9a-f]{24}$/, 'valid object id').required(),
+    });
+  }
+
+  static fromCtx(ctx) {
+    // TODO: save more metadata
+    // TODO: metadata parse helper
+    const userRegistrationMessage = new UserRegistrationMessage({
+      data: ctx.request.body,
+      meta: {
+        request_id: ctx.id,
+      },
+    });
+    return userRegistrationMessage;
+  }
+
+}
+
+module.exports = UserRegistrationMessage;

--- a/src/web/controllers/ApiWebController.js
+++ b/src/web/controllers/ApiWebController.js
@@ -24,6 +24,7 @@ class ApiWebController extends WebController {
   async v1(ctx) {
     ctx.body = {
       tools: this.fullUrl('api.v1.tools'),
+      events: this.fullUrl('api.v1.events'),
       webhooks: this.fullUrl('api.v1.webhooks'),
     };
   }

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const UserRegistrationMessage = require('../../messages/UserRegistrationMessage');
 const WebController = require('./WebController');
 
 class EventsWebController extends WebController {
@@ -17,6 +18,13 @@ class EventsWebController extends WebController {
   }
 
   async userRegistration(ctx) {
+    try {
+      const userRegistrationMessage = UserRegistrationMessage.fromCtx(ctx);
+      userRegistrationMessage.validate();
+    } catch (error) {
+      this.sendError(ctx, error);
+      return;
+    }
     this.sendOK(ctx);
   }
 }

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const WebController = require('./WebController');
+
+class EventsWebController extends WebController {
+  constructor(...args) {
+    super(...args);
+    // Bind web methods to object context so they can be passed to router.
+    this.index = this.index.bind(this);
+    this.userRegistration = this.userRegistration.bind(this);
+  }
+
+  async index(ctx) {
+    ctx.body = {
+      'user-registration': this.fullUrl('api.v1.events.user-registration'),
+    };
+  }
+
+  async userRegistration(ctx) {
+    this.sendOK(ctx);
+  }
+}
+
+module.exports = EventsWebController;

--- a/src/web/controllers/WebController.js
+++ b/src/web/controllers/WebController.js
@@ -46,17 +46,20 @@ class WebController {
     };
 
     // Check error type.
+    let level;
     if (error instanceof MessageValidationBlinkError) {
       // Machine-readable error code.
       ctx.body.code = 'error_validation_failed';
       ctx.status = 422;
+      level = 'warning';
     } else {
       ctx.body.code = 'error_unexpected_controller_error';
       ctx.status = 400;
+      level = 'error';
     }
     ctx.body.message = error.toString();
 
-    this.log('warning', ctx);
+    this.log(level, ctx);
   }
 
   log(level, ctx) {

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -58,14 +58,14 @@ test('POST /api/v1/events/user-registration should validate incoming message', a
   responseToNotUuid.status.should.be.equal(422);
   responseToNotUuid.body.should.have.property('ok', false);
   responseToNotUuid.body.should.have.property('message')
-    .and.have.string('"id" with value "not-an-uuid" fails to match the valid object id pattern');
+    .and.have.string('fails to match the valid object id pattern');
 
   // Test correct payload
   const responseValidPayload = await t.context.supertest
     .post('/api/v1/events/user-registration')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send({
-      id: '5554eac1a59dbf117e8b4567'
+      id: '5554eac1a59dbf117e8b4567',
     });
   responseValidPayload.status.should.be.equal(200);
   responseValidPayload.body.should.have.property('ok', true);

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+
+const HooksHelper = require('../../helpers/HooksHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+test.beforeEach(HooksHelper.startBlinkWebApp);
+test.afterEach(HooksHelper.stopBlinkWebApp);
+
+// ------- Tests ---------------------------------------------------------------
+
+/**
+ * GET /api/v1/events
+ */
+test('GET /api/v1/events should respond with JSON list available tools', async (t) => {
+  const res = await t.context.supertest.get('/api/v1/events')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password);
+
+  res.status.should.be.equal(200);
+
+  // Check response to be json
+  res.header.should.have.property('content-type')
+    .and.have.string('application/json');
+
+  // Check response.
+  res.body.should.have.property('user-registration')
+    .and.have.string('/api/v1/events/user-registration');
+});


### PR DESCRIPTION
#### What's this PR do?
- Creates `/api/v1/events/user-registration`
- Validates incoming message for user registration event

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
- `yarn web`
- Execute POST
  ```
  curl -X POST \
    http://localhost:5050/api/v1/events/user-registration \
    -H 'authorization: Basic Ymxpbms6Ymxpbms=' \
    -H 'cache-control: no-cache' \
    -H 'content-type: application/json' \
    -H 'postman-token: daf9eee3-fe85-209f-cae8-1862311bcf95' \
    -d '{
    "id": "5554eac1a59dbf117e8b4567"
  }'
  ```

#### What are the relevant tickets?
Pivotal [143982623](https://www.pivotaltracker.com/story/show/143982623)
