### PR TITLE
[#143982623] Replace UserRegistrationMessage with UserMessage

### DIFF
--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -56,9 +56,9 @@ class BlinkWebApp extends BlinkApp {
     // Events
     router.get('api.v1.events', '/api/v1/events', eventsWebController.index);
     router.post(
-      'api.v1.events.user-registration',
-      '/api/v1/events/user-registration',
-      eventsWebController.userRegistration
+      'api.v1.events.user-create',
+      '/api/v1/events/user-create',
+      eventsWebController.userCreate
     );
 
     // Webhooks

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -26,6 +26,21 @@ class Message {
     return true;
   }
 
+  validateStrict() {
+    const { error, value } = Joi.validate(
+      this.payload.data,
+      this.schema || {},
+      {
+        stripUnknown: true,
+      }
+    );
+    if (error) {
+      throw new MessageValidationBlinkError(error.message, this.toString());
+    }
+    this.payload.data = value;
+    return true;
+  }
+
   static parseIncomingPayload(incomingMessage) {
     let payload = false;
     const rawPayload = incomingMessage.content.toString();

--- a/src/messages/UserMessage.js
+++ b/src/messages/UserMessage.js
@@ -10,9 +10,51 @@ class UserMessage extends Message {
     super(...args);
 
     // Data validation rules.
+    // TODO: move to helpers.
+    const whenNullOrEmpty = Joi.valid(['', null]);
+    const optionalStringDefaultsToNull = Joi.string().empty(whenNullOrEmpty).default(null);
+    const optionalDateDefaultsToNull = Joi.string().isoDate().empty(whenNullOrEmpty).default(null);
+
     this.schema = Joi.object().keys({
-      id: Joi.string().regex(/^[0-9a-f]{24}$/, 'valid object id').required(),
-    });
+      id: Joi.string().required().regex(/^[0-9a-f]{24}$/, 'valid object id'),
+
+      // Treat the following as not present when provided as empty string or null.
+      email: Joi.string().empty(whenNullOrEmpty),
+      mobile: Joi.string().empty(whenNullOrEmpty),
+
+      // Required:
+      updated_at: Joi.string().required().isoDate(),
+      created_at: Joi.string().required().isoDate(),
+      // TODO: rename to mobile_status when this is closed:
+      // https://github.com/DoSomething/northstar/issues/570
+      mobilecommons_status: Joi.required().valid([
+        'active',
+        'undeliverable',
+        'unknown',
+        null,
+      ]),
+
+      // Optional, defaults to null when provided as empty string or null.
+      last_authenticated_at: optionalDateDefaultsToNull,
+      birthdate: optionalDateDefaultsToNull,
+      first_name: optionalStringDefaultsToNull,
+      last_name: optionalStringDefaultsToNull,
+      addr_city: optionalStringDefaultsToNull,
+      addr_state: optionalStringDefaultsToNull,
+      addr_zip: optionalStringDefaultsToNull,
+      source: optionalStringDefaultsToNull,
+      source_detail: optionalStringDefaultsToNull,
+      language: optionalStringDefaultsToNull,
+      country: optionalStringDefaultsToNull,
+
+      // Allow anything as a role, but dedault to user.
+      role: Joi.string().empty(whenNullOrEmpty).default('user'),
+
+      // When iterests not present, make them an empty array.
+      interests: Joi.array().items(Joi.string()).empty(whenNullOrEmpty).default([]),
+    })
+    // Require presence at least one of: keyword, args, mms_image_url.
+    .or('email', 'mobile');
   }
 
   static fromCtx(ctx) {

--- a/src/messages/UserMessage.js
+++ b/src/messages/UserMessage.js
@@ -18,9 +18,9 @@ class UserMessage extends Message {
     this.schema = Joi.object().keys({
       id: Joi.string().required().regex(/^[0-9a-f]{24}$/, 'valid object id'),
 
-      // Treat the following as not present when provided as empty string or null.
-      email: Joi.string().empty(whenNullOrEmpty),
-      mobile: Joi.string().empty(whenNullOrEmpty),
+      // Remove field when provided as empty string or null.
+      email: Joi.string().empty(whenNullOrEmpty).default(undefined),
+      mobile: Joi.string().empty(whenNullOrEmpty).default(undefined),
 
       // Required:
       updated_at: Joi.string().required().isoDate(),
@@ -47,10 +47,10 @@ class UserMessage extends Message {
       language: optionalStringDefaultsToNull,
       country: optionalStringDefaultsToNull,
 
-      // Allow anything as a role, but dedault to user.
+      // Allow anything as a role, but default to user.
       role: Joi.string().empty(whenNullOrEmpty).default('user'),
 
-      // When iterests not present, make them an empty array.
+      // When interests not present, make them an empty array.
       interests: Joi.array().items(Joi.string()).empty(whenNullOrEmpty).default([]),
     })
     // Require presence at least one of: keyword, args, mms_image_url.

--- a/src/messages/UserMessage.js
+++ b/src/messages/UserMessage.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 
 const Message = require('./Message');
 
-class UserRegistrationMessage extends Message {
+class UserMessage extends Message {
 
   constructor(...args) {
     super(...args);
@@ -18,20 +18,15 @@ class UserRegistrationMessage extends Message {
   static fromCtx(ctx) {
     // TODO: save more metadata
     // TODO: metadata parse helper
-    const userRegistrationMessage = new UserRegistrationMessage({
+    const userMessage = new UserMessage({
       data: ctx.request.body,
       meta: {
         request_id: ctx.id,
       },
     });
-    return userRegistrationMessage;
-  }
-
-  static routingKey() {
-    // TODO: unify
-    return 'registration.user.event';
+    return userMessage;
   }
 
 }
 
-module.exports = UserRegistrationMessage;
+module.exports = UserMessage;

--- a/src/queues/CustomerIoUpdateCustomerQ.js
+++ b/src/queues/CustomerIoUpdateCustomerQ.js
@@ -2,16 +2,16 @@
 
 require('isomorphic-fetch');
 
-const UserRegistrationMessage = require('../messages/UserRegistrationMessage');
+const UserMessage = require('../messages/UserMessage');
 const Queue = require('./Queue');
 
 class CustomerIoUpdateCustomerQ extends Queue {
 
   constructor(...args) {
     super(...args);
-    this.messageClass = UserRegistrationMessage;
+    this.messageClass = UserMessage;
     this.routes = [
-      UserRegistrationMessage.routingKey(),
+      'registration.user.event'
     ];
   }
 

--- a/src/queues/CustomerIoUpdateCustomerQ.js
+++ b/src/queues/CustomerIoUpdateCustomerQ.js
@@ -11,7 +11,7 @@ class CustomerIoUpdateCustomerQ extends Queue {
     super(...args);
     this.messageClass = UserMessage;
     this.routes = [
-      'registration.user.event'
+      'registration.user.event',
     ];
   }
 

--- a/src/queues/CustomerIoUpdateCustomerQ.js
+++ b/src/queues/CustomerIoUpdateCustomerQ.js
@@ -11,7 +11,7 @@ class CustomerIoUpdateCustomerQ extends Queue {
     super(...args);
     this.messageClass = UserMessage;
     this.routes = [
-      'registration.user.event',
+      'create.user.event',
     ];
   }
 

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -20,7 +20,7 @@ class EventsWebController extends WebController {
   async userRegistration(ctx) {
     try {
       const userMessage = UserMessage.fromCtx(ctx);
-      userMessage.validate();
+      userMessage.validateStrict();
       this.blink.exchange.publish(
         'registration.user.event',
         userMessage

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const UserRegistrationMessage = require('../../messages/UserRegistrationMessage');
+const UserMessage = require('../../messages/UserMessage');
 const WebController = require('./WebController');
 
 class EventsWebController extends WebController {
@@ -19,11 +19,11 @@ class EventsWebController extends WebController {
 
   async userRegistration(ctx) {
     try {
-      const userRegistrationMessage = UserRegistrationMessage.fromCtx(ctx);
-      userRegistrationMessage.validate();
+      const userMessage = UserMessage.fromCtx(ctx);
+      userMessage.validate();
       this.blink.exchange.publish(
-        UserRegistrationMessage.routingKey(),
-        userRegistrationMessage
+        'registration.user.event',
+        userMessage
       );
     } catch (error) {
       this.sendError(ctx, error);

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -8,21 +8,21 @@ class EventsWebController extends WebController {
     super(...args);
     // Bind web methods to object context so they can be passed to router.
     this.index = this.index.bind(this);
-    this.userRegistration = this.userRegistration.bind(this);
+    this.userCreate = this.userCreate.bind(this);
   }
 
   async index(ctx) {
     ctx.body = {
-      'user-registration': this.fullUrl('api.v1.events.user-registration'),
+      'user-create': this.fullUrl('api.v1.events.user-create'),
     };
   }
 
-  async userRegistration(ctx) {
+  async userCreate(ctx) {
     try {
       const userMessage = UserMessage.fromCtx(ctx);
       userMessage.validateStrict();
       this.blink.exchange.publish(
-        'registration.user.event',
+        'create.user.event',
         userMessage
       );
     } catch (error) {

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -65,8 +65,39 @@ test('POST /api/v1/events/user-registration should validate incoming message', a
     .post('/api/v1/events/user-registration')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send({
-      id: '5554eac1a59dbf117e8b4567',
-    });
+      id: '57d1aa6142a06448258b4572',
+      _id: '57d1aa6142a06448258b4572',
+      first_name: 'Sergii',
+      last_name: null,
+      last_initial: '',
+      photo: null,
+      email: 'sergii+test@dosomething.org',
+      mobile: null,
+      facebook_id: null,
+      interests: [
+        "basketball",
+        "wwe",
+      ],
+      birthdate: '1996-05-28',
+      addr_street1: null,
+      addr_street2: null,
+      addr_city: null,
+      addr_state: null,
+      addr_zip: '10001',
+      source: 'phoenix',
+      source_detail: null,
+      slack_id: null,
+      mobilecommons_id: '167181555',
+      parse_installation_ids: null,
+      mobilecommons_status: 'undeliverable',
+      language: 'en',
+      country: 'UA',
+      drupal_id: '4091040',
+      role: 'user',
+      last_authenticated_at: '2017-04-25T18:51:28+00:00',
+      updated_at: '2017-04-25T18:51:28+00:00',
+      created_at: '2016-09-08T18:13:43+00:00',
+  });
   responseValidPayload.status.should.be.equal(200);
   responseValidPayload.body.should.have.property('ok', true);
   responseValidPayload.body.should.have.property('message')

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -75,8 +75,8 @@ test('POST /api/v1/events/user-registration should validate incoming message', a
       mobile: null,
       facebook_id: null,
       interests: [
-        "basketball",
-        "wwe",
+        'basketball',
+        'wwe',
       ],
       birthdate: '1996-05-28',
       addr_street1: null,
@@ -97,7 +97,7 @@ test('POST /api/v1/events/user-registration should validate incoming message', a
       last_authenticated_at: '2017-04-25T18:51:28+00:00',
       updated_at: '2017-04-25T18:51:28+00:00',
       created_at: '2016-09-08T18:13:43+00:00',
-  });
+    });
   responseValidPayload.status.should.be.equal(200);
   responseValidPayload.body.should.have.property('ok', true);
   responseValidPayload.body.should.have.property('message')

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -61,6 +61,7 @@ test('POST /api/v1/events/user-create should validate incoming message', async (
     .and.have.string('fails to match the valid object id pattern');
 
   // Test correct payload
+  // TODO: Move data stubs outside of the test file.
   const responseValidPayload = await t.context.supertest
     .post('/api/v1/events/user-create')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -29,18 +29,18 @@ test('GET /api/v1/events should respond with JSON list available tools', async (
     .and.have.string('application/json');
 
   // Check response.
-  res.body.should.have.property('user-registration')
-    .and.have.string('/api/v1/events/user-registration');
+  res.body.should.have.property('user-create')
+    .and.have.string('/api/v1/events/user-create');
 });
 
 
 /**
- * POST /api/v1/events/user-registration
+ * POST /api/v1/events/user-create
  */
-test('POST /api/v1/events/user-registration should validate incoming message', async (t) => {
+test('POST /api/v1/events/user-create should validate incoming message', async (t) => {
   // Test empty message
   const responseToEmptyPayload = await t.context.supertest
-    .post('/api/v1/events/user-registration')
+    .post('/api/v1/events/user-create')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send({});
   responseToEmptyPayload.status.should.be.equal(422);
@@ -50,7 +50,7 @@ test('POST /api/v1/events/user-registration should validate incoming message', a
 
   // Test incorrect id
   const responseToNotUuid = await t.context.supertest
-    .post('/api/v1/events/user-registration')
+    .post('/api/v1/events/user-create')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send({
       id: 'not-an-uuid',
@@ -62,7 +62,7 @@ test('POST /api/v1/events/user-registration should validate incoming message', a
 
   // Test correct payload
   const responseValidPayload = await t.context.supertest
-    .post('/api/v1/events/user-registration')
+    .post('/api/v1/events/user-create')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send({
       id: '57d1aa6142a06448258b4572',


### PR DESCRIPTION
#### What's this PR do?
- Changes `/api/v1/events/user-create` so it accepts Northstar User fields, not Northstar user id
- Replaces `UserRegistrationMessage` with `UserMessage`, generic Northstrar User fields message
- Makes `/api/v1/events/user-create` publish  `UserMessage` to `create.user.event` route
- Renames everything userRegistration to userCreate

#### How should this be manually tested?
- `docker-compose up`
- `yarn all-tests`

#### What are the relevant tickets?
Pivotal [143982623](https://www.pivotaltracker.com/story/show/143982623)