### PR TITLE
Fix #53: rename `mobilecommons_status` to `mobile_status`

### DIFF
--- a/src/messages/CustomerIoIdentifyMessage.js
+++ b/src/messages/CustomerIoIdentifyMessage.js
@@ -79,13 +79,6 @@ class CustomerIoIdentifyMessage extends Message {
     // Remove id from data, as it's available on the top level.
     delete customerData.id;
 
-    // Rename mobilecommon_status to mobile_status
-    if (customerData.mobilecommon_status) {
-      const mobileStatus = customerData.mobilecommon_status;
-      delete customerData.mobilecommon_status;
-      customerData.mobileStatus = mobileStatus;
-    }
-
     // Rename mobile to phone
     // TODO: format phone
 

--- a/src/messages/UserMessage.js
+++ b/src/messages/UserMessage.js
@@ -26,9 +26,7 @@ class UserMessage extends Message {
       // Required:
       updated_at: Joi.string().required().isoDate(),
       created_at: Joi.string().required().isoDate(),
-      // TODO: rename to mobile_status when this is closed:
-      // https://github.com/DoSomething/northstar/issues/570
-      mobilecommons_status: Joi.valid([
+      mobile_status: Joi.valid([
         'active',
         'undeliverable',
         'unknown',

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -90,7 +90,7 @@ test('POST /api/v1/events/user-create should validate incoming message', async (
       slack_id: null,
       mobilecommons_id: '167181555',
       parse_installation_ids: null,
-      mobilecommons_status: 'undeliverable',
+      mobile_status: 'undeliverable',
       language: 'en',
       country: 'UA',
       drupal_id: '4091040',


### PR DESCRIPTION
#### What's this PR do?
- Renames `mobilecommons_status` to `mobile_status`

#### How should this be manually tested?
- `yarn all-tests`

#### What are the relevant tickets?
Fixes #53
Ref https://github.com/DoSomething/northstar/pull/575