### PR TITLE
Fix #76: checkRetrySuppress is not a static call

### DIFF
--- a/src/workers/GambitChatbotMdataProxyWorker.js
+++ b/src/workers/GambitChatbotMdataProxyWorker.js
@@ -60,7 +60,7 @@ class GambitChatbotMdataProxyWorker extends Worker {
       return true;
     }
 
-    if (GambitChatbotMdataProxyWorker.checkRetrySuppress(response)) {
+    if (this.checkRetrySuppress(response)) {
       this.log(
         'debug',
         mdataMessage,


### PR DESCRIPTION
#### What's this PR do?
- Fixes incorrect call of `GambitChatbotMdataProxyWorker.checkRetrySuppress()`.

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### Any background context you want to provide?
THANKS, @aaronschachter!

#### What are the relevant tickets?
Fixes #76