### PR TITLE
Chore: Upgrade RabbitMQ to 3.6.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   rabbitmq:
-    image: rabbitmq:3.6.9-management
+    image: rabbitmq:3.6.10-management
     environment:
       RABBITMQ_DEFAULT_USER: 'blink'
       RABBITMQ_DEFAULT_VHOST: 'blink'

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,6 @@
 box: node:8.0.0
 services:
-  - id: rabbitmq:3.6.9-management
+  - id: rabbitmq:3.6.10-management
     env:
       RABBITMQ_DEFAULT_USER: $BLINK_AMQP_USER
       RABBITMQ_DEFAULT_PASS: $BLINK_AMQP_PASSWORD


### PR DESCRIPTION
Upgrade RabbitMQ from 3.6.9 to 3.6.10 [(changelog)](https://www.rabbitmq.com/news.html#2017-05-25T18:00:00+03:00).
This release contains bug fixes and usability improvements.