### PR TITLE
Updating to Node v8.1.4 to fix DoS vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.1",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
-    "node": "8.0.0"
+    "node": "8.1.4"
   },
   "scripts": {
     "test": "NODE_ENV=test ava",


### PR DESCRIPTION
Heroku sent an email indicating that all NodeJS applications that aren't running one of the following NodeJS versions should be updated due to DoS attack vulnerabilities. 4.8.4, 6.11.1, 7.10.1, or 8.1.4. This app was running 8.0.0, and this PR updates it to 8.1.4.