### PR TITLE
Chore: replace isomorphic fetch in order to get rid of global variables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,3 @@
 module.exports = {
   extends: '@dosomething/eslint-config/nodejs/8.x',
-  globals: {
-    // Support fetch mechanism through isomorphic-fetch module
-    fetch: true,
-    Response: true,
-  },
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "koa-router": "^7.2.0",
     "moment": "^2.18.1",
     "newrelic": "^2.0.1",
+    "node-fetch": "^1.7.1",
     "throng": "^4.0.0",
     "uuid": "^3.1.0",
     "winston": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "change-case": "^3.0.1",
     "customerio-node": "^0.2.0",
     "dotenv": "^4.0.0",
-    "isomorphic-fetch": "^2.2.1",
     "joi": "^10.6.0",
     "koa": "^2.3.0",
     "koa-basic-auth": "^2.0.0",

--- a/src/lib/RabbitManagement.js
+++ b/src/lib/RabbitManagement.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('isomorphic-fetch');
+const fetch = require('node-fetch');
 const URL = require('url');
 
 class RabbitManagement {

--- a/src/queues/CustomerIoUpdateCustomerQ.js
+++ b/src/queues/CustomerIoUpdateCustomerQ.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('isomorphic-fetch');
-
 const UserMessage = require('../messages/UserMessage');
 const Queue = require('./Queue');
 

--- a/src/queues/FetchQ.js
+++ b/src/queues/FetchQ.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('isomorphic-fetch');
-
 const FetchMessage = require('../messages/FetchMessage');
 const Queue = require('./Queue');
 

--- a/src/queues/GambitChatbotMdataQ.js
+++ b/src/queues/GambitChatbotMdataQ.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('isomorphic-fetch');
-
 const MdataMessage = require('../messages/MdataMessage');
 const Queue = require('./Queue');
 

--- a/src/workers/FetchWorker.js
+++ b/src/workers/FetchWorker.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fetch = require('node-fetch');
 const logger = require('winston');
 
 const Worker = require('./Worker');

--- a/src/workers/GambitChatbotMdataProxyWorker.js
+++ b/src/workers/GambitChatbotMdataProxyWorker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('isomorphic-fetch');
+const fetch = require('node-fetch');
 const logger = require('winston');
 
 const BlinkRetryError = require('../errors/BlinkRetryError');

--- a/test/workers/GambitChatbotMdataProxyWorker.test.js
+++ b/test/workers/GambitChatbotMdataProxyWorker.test.js
@@ -2,9 +2,9 @@
 
 // ------- Imports -------------------------------------------------------------
 
-const test = require('ava');
 const chai = require('chai');
-require('isomorphic-fetch');
+const fetch = require('node-fetch');
+const test = require('ava');
 
 const BlinkWorkerApp = require('../../src/app/BlinkWorkerApp');
 const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
@@ -12,6 +12,7 @@ const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
+const { Response } = fetch;
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,6 +1402,12 @@ empower-core@^0.6.1:
     call-signature "0.0.2"
     core-js "^2.0.0"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 enhance-visitors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a"
@@ -2112,7 +2118,7 @@ iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
-iconv-lite@^0.4.17:
+iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
@@ -2400,7 +2406,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2989,6 +2995,13 @@ no-case@^2.2.0:
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-pre-gyp@^0.6.36:
   version "0.6.36"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,12 +1402,6 @@ empower-core@^0.6.1:
     call-signature "0.0.2"
     core-js "^2.0.0"
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
-
 enhance-visitors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a"
@@ -2118,7 +2112,7 @@ iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
-iconv-lite@^0.4.17, iconv-lite@~0.4.13:
+iconv-lite@^0.4.17:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
@@ -2406,7 +2400,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2453,13 +2447,6 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
-
-isomorphic-fetch@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
@@ -3002,13 +2989,6 @@ no-case@^2.2.0:
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
   dependencies:
     lower-case "^1.1.1"
-
-node-fetch@^1.0.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-pre-gyp@^0.6.36:
   version "0.6.36"
@@ -4321,10 +4301,6 @@ verror@1.3.6:
 well-known-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-1.0.0.tgz#73c78ae81a7726a8fa598e2880801c8b16225518"
-
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### What's this PR do?
- This PR replaces `isomorphic-fetch` package with `node-fetch`.

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
- `yarn web`
- `yarn worker fetch`

#### Any background context you want to provide?
Isomorphic fetch provides fetch function through Node's global scope. This opens the possibility to fetch function being required **after** being called.

In fact, fetch worker is affected by this issue now, see https://github.com/DoSomething/blink/pull/98/files#diff-35576d7c3c88818f76aeaac62500c18aR3. I forgot to explicitly require `isomorphic-fetch` in this package, but the worker still works because the package has been required in another file not related to this worker.

Using `node-fetch` to explicitly access `fetch()` and related classes mitigates potential critical error in the code.

#### What are the relevant tickets?
Fixes #93