### PR TITLE
[#150022903] Rename user reportback to user signup post

### DIFF
--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -10,7 +10,7 @@ const FetchQ = require('../queues/FetchQ');
 const GambitChatbotMdataQ = require('../queues/GambitChatbotMdataQ');
 const MocoMessageDataQ = require('../queues/MocoMessageDataQ');
 const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
-const UserReportbackEventQ = require('../queues/UserReportbackEventQ');
+const UserSignupPostEventQ = require('../queues/UserSignupPostEventQ');
 const UserSignupEventQ = require('../queues/UserSignupEventQ');
 
 class BlinkApp {
@@ -50,7 +50,7 @@ class BlinkApp {
         GambitChatbotMdataQ,
         MocoMessageDataQ,
         QuasarCustomerIoEmailActivityQ,
-        UserReportbackEventQ,
+        UserSignupPostEventQ,
         UserSignupEventQ,
       ]);
     } catch (error) {

--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -66,9 +66,9 @@ class BlinkWebApp extends BlinkApp {
       eventsWebController.userSignup,
     );
     router.post(
-      'api.v1.events.user-reportback',
-      '/api/v1/events/user-reportback',
-      eventsWebController.userReportback,
+      'api.v1.events.user-signup-post',
+      '/api/v1/events/user-signup-post',
+      eventsWebController.userSignupPost,
     );
 
     // Webhooks

--- a/src/queues/UserSignupPostEventQ.js
+++ b/src/queues/UserSignupPostEventQ.js
@@ -3,12 +3,12 @@
 const FreeFormMessage = require('../messages/FreeFormMessage');
 const Queue = require('./Queue');
 
-class UserReportbackEventQ extends Queue {
+class UserSignupPostEventQ extends Queue {
   constructor(...args) {
     super(...args);
     this.messageClass = FreeFormMessage;
-    this.routes.push('repotback.user.event');
+    this.routes.push('signup-post.user.event');
   }
 }
 
-module.exports = UserReportbackEventQ;
+module.exports = UserSignupPostEventQ;

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -11,14 +11,14 @@ class EventsWebController extends WebController {
     this.index = this.index.bind(this);
     this.userCreate = this.userCreate.bind(this);
     this.userSignup = this.userSignup.bind(this);
-    this.userReportback = this.userReportback.bind(this);
+    this.userSignupPost = this.userSignupPost.bind(this);
   }
 
   async index(ctx) {
     ctx.body = {
       'user-create': this.fullUrl('api.v1.events.user-create'),
       'user-signup': this.fullUrl('api.v1.events.user-signup'),
-      'user-reportback': this.fullUrl('api.v1.events.user-reportback'),
+      'user-signup-post': this.fullUrl('api.v1.events.user-signup-post'),
     };
   }
 
@@ -50,12 +50,12 @@ class EventsWebController extends WebController {
     }
   }
 
-  async userReportback(ctx) {
+  async userSignupPost(ctx) {
     try {
       const freeFormMessage = FreeFormMessage.fromCtx(ctx);
       freeFormMessage.validate();
       this.blink.exchange.publish(
-        'repotback.user.event',
+        'signup-post.user.event',
         freeFormMessage,
       );
       this.sendOK(ctx, freeFormMessage);

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -148,9 +148,9 @@ test('POST /api/v1/events/user-signup should publish message to user-signup-even
 });
 
 /**
- * POST /api/v1/events/user-signup
+ * POST /api/v1/events/user-signup-post
  */
-test('POST /api/v1/events/user-reportback should publish message to user-reportback-event', async (t) => {
+test('POST /api/v1/events/user-signup-post should publish message to user-signup-post-event', async (t) => {
   const data = {
     random: 'key',
     nested: {
@@ -158,7 +158,7 @@ test('POST /api/v1/events/user-reportback should publish message to user-reportb
     },
   };
 
-  const res = await t.context.supertest.post('/api/v1/events/user-reportback')
+  const res = await t.context.supertest.post('/api/v1/events/user-signup-post')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send(data);
 
@@ -174,7 +174,7 @@ test('POST /api/v1/events/user-reportback should publish message to user-reportb
   // Check that the message is queued.
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);
   // TODO: queue cleanup to make sure that it's not OLD message.
-  const messages = await rabbit.getMessagesFrom('user-reportback-event', 1);
+  const messages = await rabbit.getMessagesFrom('user-signup-post-event', 1);
   messages.should.be.an('array').and.to.have.lengthOf(1);
 
   messages[0].should.have.property('payload');

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -34,8 +34,8 @@ test('GET /api/v1/events should respond with JSON list available tools', async (
     .and.have.string('/api/v1/events/user-create');
   res.body.should.have.property('user-signup')
     .and.have.string('/api/v1/events/user-signup');
-  res.body.should.have.property('user-reportback')
-    .and.have.string('/api/v1/events/user-reportback');
+  res.body.should.have.property('user-signup-post')
+    .and.have.string('/api/v1/events/user-signup-post');
 });
 
 


### PR DESCRIPTION
#### What's this PR do?
- Renames `/api/v1/events/user-reportback` to `/api/v1/events/user-signup-post`

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### Any background context you want to provide?
Campaign reportbacks has been renamed to user signup posts in Rogue: https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/posts.md.

#### What are the relevant tickets?
Pivotal [150022903](https://www.pivotaltracker.com/story/show/150022903)