### PR TITLE
Bump 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
     "node": "8.3.0"


### PR DESCRIPTION
Pre production release bump to 1.3.0.

Also, looks like I forgot to bump the version to 1.2.0 in package JSON,  even though I create a tag.