### PR TITLE
[#150496291] Send user campaign signups to customer.io

### DIFF
--- a/src/messages/CustomerIoCampaignSignupEventMessage.js
+++ b/src/messages/CustomerIoCampaignSignupEventMessage.js
@@ -56,7 +56,8 @@ class CustomerIoCampaignSignupEventMessage extends Message {
   toCustomerIoEvent() {
     const data = this.getData();
     const eventData = {
-      signup_id: data.id,
+      // Convert signup id to a string for consistency.
+      signup_id: String(data.id),
       campaign_id: data.campaign_id,
       campaign_run_id: data.campaign_run_id,
     };

--- a/src/workers/CustomerIoCampaignSignupEventWorker.js
+++ b/src/workers/CustomerIoCampaignSignupEventWorker.js
@@ -27,10 +27,9 @@ class CustomerIoCampaignSignupEventWorker extends Worker {
     const msgData = campaignSignupEventMessage.getData();
     let meta;
 
-    // Convert campaign signup event to cio event.
+    // Convert campaign signup to customer.io event.
     let customerIoEvent;
     try {
-      // Convert campaign signup to customer.io event.
       customerIoEvent = campaignSignupEventMessage.toCustomerIoEvent();
     } catch (error) {
       meta = {

--- a/src/workers/CustomerIoCampaignSignupEventWorker.js
+++ b/src/workers/CustomerIoCampaignSignupEventWorker.js
@@ -30,7 +30,7 @@ class CustomerIoCampaignSignupEventWorker extends Worker {
     // Convert campaign signup event to cio event.
     let customerIoEvent;
     try {
-      // For now all messages are new
+      // Convert campaign signup to customer.io event.
       customerIoEvent = campaignSignupEventMessage.toCustomerIoEvent();
     } catch (error) {
       meta = {

--- a/src/workers/CustomerIoCampaignSignupEventWorker.js
+++ b/src/workers/CustomerIoCampaignSignupEventWorker.js
@@ -3,7 +3,7 @@
 const CIO = require('customerio-node');
 const logger = require('winston');
 
-// const BlinkRetryError = require('../errors/BlinkRetryError');
+const BlinkRetryError = require('../errors/BlinkRetryError');
 const Worker = require('./Worker');
 
 class CustomerIoCampaignSignupEventWorker extends Worker {
@@ -25,6 +25,7 @@ class CustomerIoCampaignSignupEventWorker extends Worker {
   async consume(campaignSignupEventMessage) {
     // Helper variables.
     const msgData = campaignSignupEventMessage.getData();
+    let meta;
 
     // Convert campaign signup event to cio event.
     let customerIoEvent;

--- a/src/workers/CustomerIoCampaignSignupEventWorker.js
+++ b/src/workers/CustomerIoCampaignSignupEventWorker.js
@@ -68,6 +68,8 @@ class CustomerIoCampaignSignupEventWorker extends Worker {
       'Customer.io campaign signup tracked',
       'success_cio_track_campaign_signup',
     );
+
+    return true;
   }
 
   async log(level, message, text, code = 'unexpected_code') {

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -185,7 +185,7 @@ class MessageFactoryHelper {
 
     return new CustomerIoCampaignSignupEventMessage({
       data: {
-        id: chance.integer(),
+        id: chance.integer({ min: 0 }),
         northstar_id: chance.hash({ length: 24 }),
         campaign_id: { length: 4, pool: '1234567890' },
         campaign_run_id: { length: 4, pool: '1234567890' },

--- a/test/messages/CustomerIoCampaignSignupEventMessage.test.js
+++ b/test/messages/CustomerIoCampaignSignupEventMessage.test.js
@@ -39,7 +39,7 @@ test('Campaign signup message should be correctly transformed to CustomerIoEvent
     cioEvent.getName().should.equal('campaign_signup');
     const eventData = cioEvent.getData();
 
-    eventData.signup_id.should.equal(data.id);
+    eventData.signup_id.should.equal(String(data.id));
     eventData.campaign_id.should.equal(data.campaign_id);
     eventData.campaign_run_id.should.equal(data.campaign_run_id);
 


### PR DESCRIPTION
#### What's this PR do?
- Posts user campaign signups to customer.io

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### Any background context you want to provide?
One last concern is we need to double check that the iso date to timestamps transformation accounts for event timezone.

Rogue sends `created_at` field in GMT iso date, for example `2017-09-14T18:27:21+00:00`. This is transformed to unix time as 1505413641. Unix time resolves to `09/14/2017 @ 6:43pm (UTC)`, which seems to be correct.

However, c.io documentation is kind of vague on what timezone is used when segments are being built. Moreover, c.io [documentation](https://learn.customer.io/documentation/dates-timezones.html) is down now, so I'll address this issue in another pull request.

#### What are the relevant tickets?
Pivotal [150496291](https://www.pivotaltracker.com/story/show/150496291)