### PR TITLE
Extend cio event with optional version attribute

### DIFF
--- a/src/messages/CampaignSignupMessage.js
+++ b/src/messages/CampaignSignupMessage.js
@@ -73,6 +73,10 @@ class CampaignSignupMessage extends Message {
       'campaign_signup',
       eventData,
     );
+
+    // Signup -> customer.io event transformation would only happen in this class.
+    // It's safe to hardcode schema event version here.
+    // Please bump it this when data schema changes.
     event.setVersion(1);
     return event;
   }

--- a/src/messages/CampaignSignupMessage.js
+++ b/src/messages/CampaignSignupMessage.js
@@ -68,7 +68,13 @@ class CampaignSignupMessage extends Message {
       eventData.source = data.source;
     }
 
-    return new CustomerIoEvent(data.northstar_id, 'campaign_signup', eventData);
+    const event = new CustomerIoEvent(
+      data.northstar_id,
+      'campaign_signup',
+      eventData,
+    );
+    event.setVersion(1);
+    return event;
   }
 }
 

--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -95,6 +95,9 @@ class CampaignSignupPostMessage extends Message {
       'campaign_signup_post',
       eventData,
     );
+    // Signup post -> customer.io event transformation would only happen in this class.
+    // It's safe to hardcode schema event version here.
+    // Please bump it this when data schema changes.
     event.setVersion(1);
     return event;
   }

--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -90,7 +90,13 @@ class CampaignSignupPostMessage extends Message {
       }
     });
 
-    return new CustomerIoEvent(data.northstar_id, 'campaign_signup_post', eventData);
+    const event = new CustomerIoEvent(
+      data.northstar_id,
+      'campaign_signup_post',
+      eventData,
+    );
+    event.setVersion(1);
+    return event;
   }
 }
 

--- a/src/models/CustomerIoEvent.js
+++ b/src/models/CustomerIoEvent.js
@@ -19,6 +19,7 @@ class CustomerIoEvent {
     return this.data;
   }
 
+  // Schema version of event data.
   setVersion(version) {
     this.data.version = version;
   }

--- a/src/models/CustomerIoEvent.js
+++ b/src/models/CustomerIoEvent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 class CustomerIoEvent {
-  constructor(id, name, data, version) {
+  constructor(id, name, data) {
     this.id = id;
     this.name = name;
     this.data = data;

--- a/src/models/CustomerIoEvent.js
+++ b/src/models/CustomerIoEvent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 class CustomerIoEvent {
-  constructor(id, name, data) {
+  constructor(id, name, data, version) {
     this.id = id;
     this.name = name;
     this.data = data;
@@ -17,6 +17,10 @@ class CustomerIoEvent {
 
   getData() {
     return this.data;
+  }
+
+  setVersion(version) {
+    this.data.version = version;
   }
 }
 

--- a/test/messages/CampaignSignupMessage.test.js
+++ b/test/messages/CampaignSignupMessage.test.js
@@ -37,7 +37,10 @@ test('Campaign signup message should be correctly transformed to CustomerIoEvent
 
     cioEvent.getId().should.equal(data.northstar_id);
     cioEvent.getName().should.equal('campaign_signup');
+
+    // Event data.
     const eventData = cioEvent.getData();
+    eventData.version.should.equal(1);
 
     eventData.signup_id.should.equal(String(data.id));
     eventData.campaign_id.should.equal(data.campaign_id);

--- a/test/messages/CampaignSignupPostMessage.test.js
+++ b/test/messages/CampaignSignupPostMessage.test.js
@@ -38,7 +38,9 @@ test('Campaign signup post message should be correctly transformed to CustomerIo
     cioEvent.getId().should.equal(data.northstar_id);
     cioEvent.getName().should.equal('campaign_signup_post');
 
+    // Event data.
     const eventData = cioEvent.getData();
+    eventData.version.should.equal(1);
 
     eventData.signup_post_id.should.equal(String(data.id));
     eventData.signup_id.should.equal(String(data.signup_id));


### PR DESCRIPTION
#### What's this PR do?
Extend signup and signup post customer.io event attributes with `version` to indicate schema changes.

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
