### PR TITLE
Add type field to c.io campaign_signup_post events

### DIFF
--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -90,6 +90,12 @@ class CampaignSignupPostMessage extends Message {
       }
     });
 
+    // In future, Rogue will pass different campaign_signup_post types
+    // for different kind of member actions. Now everything is considered
+    // as 'action', which corresponds with "classic" Phoenix reportback.
+    // @see https://github.com/DoSomething/blink/issues/125
+    eventData.type = 'action';
+
     const event = new CustomerIoEvent(
       data.northstar_id,
       'campaign_signup_post',

--- a/test/messages/CampaignSignupPostMessage.test.js
+++ b/test/messages/CampaignSignupPostMessage.test.js
@@ -42,6 +42,7 @@ test('Campaign signup post message should be correctly transformed to CustomerIo
     const eventData = cioEvent.getData();
     eventData.version.should.equal(1);
 
+    eventData.type.should.equal('action');
     eventData.signup_post_id.should.equal(String(data.id));
     eventData.signup_id.should.equal(String(data.signup_id));
     eventData.campaign_id.should.equal(data.campaign_id);


### PR DESCRIPTION
#### What's this PR do?
- This PR adds hardcoded type field to `campaign_signup_post` events to indicate them as "actions" (previously known as reportbacks). See #125 for more details.

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### What are the relevant tickets?
Ref #125 