### PR TITLE
Bump 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
     "node": "8.5.0"


### PR DESCRIPTION
Ooops. Forgot to bump the version in `package.json` for last minor release.