### PR TITLE
Change default campaign signup post type from action to photo

### DIFF
--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -92,9 +92,9 @@ class CampaignSignupPostMessage extends Message {
 
     // In future, Rogue will pass different campaign_signup_post types
     // for different kind of member actions. Now everything is considered
-    // as 'action', which corresponds with "classic" Phoenix reportback.
+    // as 'photo', which corresponds with "classic" Phoenix reportback.
     // @see https://github.com/DoSomething/blink/issues/125
-    eventData.type = 'action';
+    eventData.type = 'photo';
 
     const event = new CustomerIoEvent(
       data.northstar_id,
@@ -104,7 +104,7 @@ class CampaignSignupPostMessage extends Message {
     // Signup post -> customer.io event transformation would only happen in this class.
     // It's safe to hardcode schema event version here.
     // Please bump it this when data schema changes.
-    event.setVersion(1);
+    event.setVersion(2);
     return event;
   }
 }

--- a/test/messages/CampaignSignupPostMessage.test.js
+++ b/test/messages/CampaignSignupPostMessage.test.js
@@ -40,9 +40,9 @@ test('Campaign signup post message should be correctly transformed to CustomerIo
 
     // Event data.
     const eventData = cioEvent.getData();
-    eventData.version.should.equal(1);
+    eventData.version.should.equal(2);
 
-    eventData.type.should.equal('action');
+    eventData.type.should.equal('photo');
     eventData.signup_post_id.should.equal(String(data.id));
     eventData.signup_id.should.equal(String(data.signup_id));
     eventData.campaign_id.should.equal(data.campaign_id);


### PR DESCRIPTION
#### What's this PR do?
- Changes default campaign signup post type from action to photo

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #130
Ref #125 