### PR TITLE
Adds support for SMS-related fields.

### DIFF
--- a/src/messages/CustomerIoUpdateCustomerMessage.js
+++ b/src/messages/CustomerIoUpdateCustomerMessage.js
@@ -44,8 +44,9 @@ class CustomerIoUpdateCustomerMessage extends Message {
           .timestamp('unix')
           .raw(),
 
-        mobile_status: Joi.valid([
+        sms_status: Joi.valid([
           'active',
+          'less',
           'undeliverable',
           'unknown',
           null,

--- a/src/messages/CustomerIoUpdateCustomerMessage.js
+++ b/src/messages/CustomerIoUpdateCustomerMessage.js
@@ -29,8 +29,7 @@ class CustomerIoUpdateCustomerMessage extends Message {
         // Remove field when provided as empty string or null.
         email: Joi.string().empty(whenNullOrEmpty).default(undefined),
 
-        // TODO: make sure has E.164 format
-        // phone: Joi.string().empty(whenNullOrEmpty).default(undefined),
+        phone: Joi.string().empty(whenNullOrEmpty).default(undefined),
 
         // Required:
         updated_at: Joi.date()
@@ -80,9 +79,7 @@ class CustomerIoUpdateCustomerMessage extends Message {
         interests: Joi.array().items(Joi.string()).empty(null).default(undefined),
 
         // TODO: add more cio specific fields, like unsubscribed_at
-      }),
-      // TODO: Bring back when phone is formatted in Northstar
-      // .or('email', 'phone'),
+      }).or('email', 'phone'),
     });
   }
 
@@ -94,13 +91,9 @@ class CustomerIoUpdateCustomerMessage extends Message {
     delete customerData.id;
 
     // Rename mobile to phone
-    // TODO: format phone
-
     if (customerData.mobile) {
-      // const mobile = customerData.mobile;
+      customerData.phone = customerData.mobile;
       delete customerData.mobile;
-      // TODO: Bring back when phone is formatted in Northstar
-      // customerData.phone = mobile;
     }
 
     customerData.created_at = moment(customerData.created_at, moment.ISO_8601).unix();

--- a/src/messages/UserMessage.js
+++ b/src/messages/UserMessage.js
@@ -25,8 +25,9 @@ class UserMessage extends Message {
       // Required:
       updated_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
       created_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
-      mobile_status: Joi.valid([
+      sms_status: Joi.valid([
         'active',
+        'less',
         'undeliverable',
         'unknown',
         null,

--- a/src/workers/CustomerIoUpdateCustomerWorker.js
+++ b/src/workers/CustomerIoUpdateCustomerWorker.js
@@ -25,17 +25,6 @@ class CustomerIoUpdateCustomerWorker extends Worker {
 
   async consume(userMessage) {
     let meta;
-    if (userMessage.isMobileOnly()) {
-      meta = {
-        env: this.blink.config.app.env,
-        code: 'cio_update_skip_mobile_only',
-        worker: this.constructor.name,
-        request_id: userMessage ? userMessage.getRequestId() : 'not_parsed',
-      };
-      logger.debug(`Skipping mobile only user ${userMessage.getData().id}`, meta);
-      return true;
-    }
-
     let customerIoUpdateCustomerMessage;
     try {
       // For now all messages are new

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -79,9 +79,10 @@ class MessageFactoryHelper {
           email: chance.email(),
           updated_at: chance.timestamp(),
           created_at: chance.timestamp(),
-          mobile_status: chance.pickone([
+          sms_status: chance.pickone([
             'undeliverable',
             'active',
+            'less',
             'unknown',
             null,
             undefined,

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -85,7 +85,6 @@ class MessageFactoryHelper {
             'less',
             'unknown',
             null,
-            undefined,
           ]),
           last_authenticated_at: chance.timestamp(),
           birthdate: moment(chance.birthday({ type: 'teen' })).format('YYYY-MM-DD'),

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -46,8 +46,9 @@ class MessageFactoryHelper {
         slack_id: chance.natural().toString(),
         mobilecommons_id: chance.natural().toString(),
         parse_installation_ids: chance.n(chance.guid, 2),
-        mobile_status: chance.pickone([
+        sms_status: chance.pickone([
           'undeliverable',
+          'less',
           'active',
           'unknown',
           null,

--- a/test/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -161,7 +161,7 @@ test('Cio identify created from Northstar is correct', () => {
     );
 
     // Optional:
-    if (cioUpdateAttributes.mobile_status) {
+    if (cioUpdateAttributes.sms_status) {
       expect(cioUpdateAttributes.sms_status).to.be.equal(
         userData.sms_status,
       );

--- a/test/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -104,7 +104,7 @@ test('Cio identify should fail on incorrect types', () => {
     email: chance.integer(),
     updated_at: chance.date().toISOString(),
     created_at: chance.date().toISOString(),
-    // no mobile_status
+    // no sms_status
     last_authenticated_at: chance.date().toISOString(),
     birthdate: chance.timestamp(),
     facebook_id: chance.fbid(),

--- a/test/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -128,7 +128,7 @@ test('Cio identify should fail on incorrect types', () => {
 });
 
 
-test('Cio identify created from Northsar is correct', () => {
+test('Cio identify created from Northstar is correct', () => {
   let count = 100;
   while (count > 0) {
     const userMessage = MessageFactoryHelper.getValidUser();
@@ -148,6 +148,7 @@ test('Cio identify created from Northsar is correct', () => {
     cioUpdateData.should.have.property('id', userData.id);
     cioUpdateData.should.have.property('data').and.to.be.an('object');
     cioUpdateData.data.should.have.property('email', userData.email);
+    cioUpdateData.data.should.have.property('phone', userData.mobile);
 
     const cioUpdateAttributes = cioUpdateData.data;
     cioUpdateAttributes.should.have.property(

--- a/test/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -69,7 +69,7 @@ test('Cio identify should fail if required fields are missing, undefined, null, 
 
 test('Cio identify should remove certain optional fields when empty', () => {
   [
-    'mobile_status',
+    'sms_status',
     'last_authenticated_at',
     'birthdate',
     'facebook_id',
@@ -161,8 +161,8 @@ test('Cio identify created from Northsar is correct', () => {
 
     // Optional:
     if (cioUpdateAttributes.mobile_status) {
-      expect(cioUpdateAttributes.mobile_status).to.be.equal(
-        userData.mobile_status,
+      expect(cioUpdateAttributes.sms_status).to.be.equal(
+        userData.sms_status,
       );
     }
     expect(cioUpdateAttributes.last_authenticated_at).to.be.equal(

--- a/test/messages/UserMessage.test.js
+++ b/test/messages/UserMessage.test.js
@@ -76,7 +76,7 @@ test('User Message optional fields should have correct default values', () => {
     country: null,
     role: 'user',
     interests: null,
-    mobile_status: null,
+    sms_status: null,
   };
   Object.entries(mapping).forEach(([field, defaultValue]) => {
     MessageValidationHelper.defaultsToWhenEmpty(field, defaultValue, generator, mutator);
@@ -90,7 +90,7 @@ test('User Message should fail on incorrect types', () => {
     mobile: chance.integer(),
     updated_at: chance.integer(),
     created_at: chance.integer(),
-    // no mobile_status
+    // no sms_status
     last_authenticated_at: chance.integer(),
     birthdate: chance.integer(),
     facebook_id: chance.integer(),

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -96,7 +96,7 @@ test('POST /api/v1/events/user-create should validate incoming message', async (
       slack_id: null,
       mobilecommons_id: '167181555',
       parse_installation_ids: null,
-      mobile_status: 'undeliverable',
+      sms_status: 'undeliverable',
       language: 'en',
       country: 'UA',
       drupal_id: '4091040',


### PR DESCRIPTION
### Changes
This pull request adds support for SMS related fields in Customer.io!

📝 Renames `mobile_status` to `sms_status` to be consistent with naming in Northstar. Since we haven't been sending phone numbers to Customer.io, this should still be safe to change. (24fa2a0)

☎️ Adds support for the E.164-formatted `mobile` field. (be8c04c)


### How should this be reviewed?
Let me know if there are any things I'm missing!