### PR TITLE
Set 'unsubscribed' in Customer.io for new email users.

### DIFF
--- a/src/messages/CustomerIoUpdateCustomerMessage.js
+++ b/src/messages/CustomerIoUpdateCustomerMessage.js
@@ -68,9 +68,7 @@ class CustomerIoUpdateCustomerMessage extends Message {
         language: optionalStringDefaultsToUndefined,
         country: optionalStringDefaultsToUndefined,
         facebook_id: optionalStringDefaultsToUndefined,
-        // TODO: Only explicitly set for new users.
         unsubscribed: Joi.boolean().empty(whenNullOrEmpty).default(undefined),
-        subscribed_at: optionalTimestampDefaultsToUndefined,
 
         // Allow anything as a role, but default to user.
         role: Joi.string().empty(whenNullOrEmpty).default('user'),
@@ -117,7 +115,6 @@ class CustomerIoUpdateCustomerMessage extends Message {
     const isNew = customerData.created_at === customerData.updated_at;
     if (customerData.email && isNew) {
       customerData.unsubscribed = false;
-      customerData.subscribed_at = moment().unix();
     }
 
     const customerIoUpdateCustomerMessage = new CustomerIoUpdateCustomerMessage({

--- a/src/messages/CustomerIoUpdateCustomerMessage.js
+++ b/src/messages/CustomerIoUpdateCustomerMessage.js
@@ -85,7 +85,7 @@ class CustomerIoUpdateCustomerMessage extends Message {
     });
   }
 
-  static fromUser(userMessage, isNew = false) {
+  static fromUser(userMessage) {
     const user = userMessage.getData();
     // Copy user fields.
     const customerData = Object.assign({}, user);
@@ -112,7 +112,10 @@ class CustomerIoUpdateCustomerMessage extends Message {
       ).unix();
     }
 
-    if (isNew) {
+    // If a user is newly created (created_at & updated_at are the same)
+    // then set them as "subscribed" to emails in Customer.io!
+    const isNew = customerData.created_at === customerData.updated_at;
+    if (customerData.email && isNew) {
       customerData.unsubscribed = false;
       customerData.subscribed_at = moment().unix();
     }

--- a/src/workers/CustomerIoUpdateCustomerWorker.js
+++ b/src/workers/CustomerIoUpdateCustomerWorker.js
@@ -38,11 +38,7 @@ class CustomerIoUpdateCustomerWorker extends Worker {
 
     let customerIoUpdateCustomerMessage;
     try {
-      // For now all messages are new
-      customerIoUpdateCustomerMessage = CustomerIoUpdateCustomerMessage.fromUser(
-        userMessage,
-        true,
-      );
+      customerIoUpdateCustomerMessage = CustomerIoUpdateCustomerMessage.fromUser(userMessage);
       customerIoUpdateCustomerMessage.validateStrict();
     } catch (error) {
       meta = {

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -23,6 +23,7 @@ const chance = new Chance();
 class MessageFactoryHelper {
   static getValidUser() {
     const fakeId = chance.hash({ length: 24 });
+    const createdAt = chance.date({ year: chance.year({ min: 2000, max: 2010 }) }).toISOString();
     return new UserMessage({
       data: {
         id: fakeId,
@@ -62,8 +63,8 @@ class MessageFactoryHelper {
         last_authenticated_at: chance.date({
           year: chance.year({ min: 2013, max: 2015 }),
         }).toISOString(),
-        updated_at: chance.date({ year: chance.year({ min: 2011, max: 2012 }) }).toISOString(),
-        created_at: chance.date({ year: chance.year({ min: 2000, max: 2010 }) }).toISOString(),
+        updated_at: createdAt,
+        created_at: createdAt,
       },
       meta: {},
     });

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -99,7 +99,6 @@ class MessageFactoryHelper {
           language: chance.locale({ region: false }),
           country: chance.country(),
           unsubscribed: chance.bool(),
-          subscribed_at: chance.timestamp(),
           role: chance.pickone(['user', 'admin', 'staff']),
           interests: chance.n(chance.word, chance.natural({ min: 0, max: 20 })),
         },

--- a/test/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -83,7 +83,6 @@ test('Cio identify should remove certain optional fields when empty', () => {
     'language',
     'country',
     'unsubscribed',
-    'subscribed_at',
   ]
     .forEach(field => MessageValidationHelper.removesWhenEmpty(field, generator, mutator));
 });
@@ -118,7 +117,6 @@ test('Cio identify should fail on incorrect types', () => {
     language: chance.integer(),
     country: chance.integer(),
     unsubscribed: chance.word(),
-    subscribed_at: chance.date().toISOString(),
     role: chance.integer(),
     interests: chance.word(),
   };
@@ -196,7 +194,6 @@ test('Cio identify created from Northsar is correct', () => {
       userData.country,
     );
     expect(cioUpdateAttributes.unsubscribed).to.be.equal(false);
-    cioUpdateAttributes.should.have.property('subscribed_at');
     expect(cioUpdateAttributes.role).to.be.equal(
       userData.role,
     );


### PR DESCRIPTION
### Changes
This pull request adds some logic to determine whether a user is newly created by comparing their `created_at` and `updated_at` values, which means we'll be able to start sending user updates without automatically re-subscribing people.

We're currently assuming that `unsubscribed` is only relevant for users with email addresses, since we want to track SMS subscription status separately in the `sms_status` field. (Waiting to hear back from Customer.io to see if we need to do some extra work here!)

### How should this be reviewed?
I updated the user returned from the `getValidUser` method to be "new" so that the existing tests continue to pass. If it makes sense, I'm also up for adding a few new test cases here for user updates & new users without email addresses.