### PR TITLE
[#151266069] Ingest Twilio sms broadcast data to twilio-sms-broadcast-gambit-relay queue

### DIFF
--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -5,13 +5,14 @@ const logger = require('winston');
 
 const Exchange = require('../lib/Exchange');
 
+const CustomerIoCampaignSignupPostQ = require('../queues/CustomerIoCampaignSignupPostQ');
+const CustomerIoCampaignSignupQ = require('../queues/CustomerIoCampaignSignupQ');
 const CustomerIoUpdateCustomerQ = require('../queues/CustomerIoUpdateCustomerQ');
 const FetchQ = require('../queues/FetchQ');
 const GambitChatbotMdataQ = require('../queues/GambitChatbotMdataQ');
 const MocoMessageDataQ = require('../queues/MocoMessageDataQ');
 const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
-const CustomerIoCampaignSignupPostQ = require('../queues/CustomerIoCampaignSignupPostQ');
-const CustomerIoCampaignSignupQ = require('../queues/CustomerIoCampaignSignupQ');
+const TwilioSmsBroadcastGambitRelayQ = require('../queues/TwilioSmsBroadcastGambitRelayQ');
 
 class BlinkApp {
   constructor(config) {
@@ -45,13 +46,14 @@ class BlinkApp {
 
       // Initialize and setup all available queues.
       this.queues = await this.setupQueues([
+        CustomerIoCampaignSignupPostQ,
+        CustomerIoCampaignSignupQ,
         CustomerIoUpdateCustomerQ,
         FetchQ,
         GambitChatbotMdataQ,
         MocoMessageDataQ,
         QuasarCustomerIoEmailActivityQ,
-        CustomerIoCampaignSignupPostQ,
-        CustomerIoCampaignSignupQ,
+        TwilioSmsBroadcastGambitRelayQ,
       ]);
     } catch (error) {
       this.connecting = false;

--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -88,6 +88,11 @@ class BlinkWebApp extends BlinkApp {
       '/api/v1/webhooks/moco-message-data',
       webHooksWebController.mocoMessageData,
     );
+    router.post(
+      'api.v1.webhooks.twilio-sms-broadcast',
+      '/api/v1/webhooks/twilio-sms-broadcast',
+      webHooksWebController.twilioSmsBroadcast,
+    );
     return router;
   }
 

--- a/src/messages/TwilioStatusCallbackMessage.js
+++ b/src/messages/TwilioStatusCallbackMessage.js
@@ -5,7 +5,7 @@ const Joi = require('joi');
 const Message = require('./Message');
 const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 
-class TwillioStatusCallbackMessage extends Message {
+class TwilioStatusCallbackMessage extends Message {
   constructor(...args) {
     super(...args);
 
@@ -32,7 +32,7 @@ class TwillioStatusCallbackMessage extends Message {
       meta.query = ctx.query;
     }
 
-    const message = new TwillioStatusCallbackMessage({
+    const message = new TwilioStatusCallbackMessage({
       data: ctx.request.body,
       meta,
     });
@@ -47,7 +47,7 @@ class TwillioStatusCallbackMessage extends Message {
 
     // TODO: save more metadata
     // TODO: metadata parse helper
-    const message = new TwillioStatusCallbackMessage({
+    const message = new TwilioStatusCallbackMessage({
       data: payload.data,
       meta: payload.meta,
     });
@@ -56,4 +56,4 @@ class TwillioStatusCallbackMessage extends Message {
   }
 }
 
-module.exports = TwillioStatusCallbackMessage;
+module.exports = TwilioStatusCallbackMessage;

--- a/src/messages/TwillioStatusCallbackMessage.js
+++ b/src/messages/TwillioStatusCallbackMessage.js
@@ -21,13 +21,21 @@ class TwillioStatusCallbackMessage extends Message {
   static fromCtx(ctx) {
     // TODO: save more metadata
     // TODO: metadata parse helper
-    const freeFormMessage = new TwillioStatusCallbackMessage({
+
+    const meta = {
+      request_id: ctx.id,
+    };
+
+    // Save GET params when present.
+    if (ctx.query && Object.keys(ctx.query).length) {
+      meta['query'] = ctx.query;
+    }
+
+    const message = new TwillioStatusCallbackMessage({
       data: ctx.request.body,
-      meta: {
-        request_id: ctx.id,
-      },
+      meta,
     });
-    return freeFormMessage;
+    return message;
   }
 
   static fromRabbitMessage(rabbitMessage) {

--- a/src/messages/TwillioStatusCallbackMessage.js
+++ b/src/messages/TwillioStatusCallbackMessage.js
@@ -29,7 +29,7 @@ class TwillioStatusCallbackMessage extends Message {
     // Save GET params when present.
     // TODO: move to generic function for all messages?
     if (ctx.query && Object.keys(ctx.query).length) {
-      meta['query'] = ctx.query;
+      meta.query = ctx.query;
     }
 
     const message = new TwillioStatusCallbackMessage({

--- a/src/messages/TwillioStatusCallbackMessage.js
+++ b/src/messages/TwillioStatusCallbackMessage.js
@@ -27,6 +27,7 @@ class TwillioStatusCallbackMessage extends Message {
     };
 
     // Save GET params when present.
+    // TODO: move to generic function for all messages?
     if (ctx.query && Object.keys(ctx.query).length) {
       meta['query'] = ctx.query;
     }

--- a/src/queues/MocoMessageDataQ.js
+++ b/src/queues/MocoMessageDataQ.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const TwillioStatusCallbackMessage = require('../messages/TwillioStatusCallbackMessage');
+const TwilioStatusCallbackMessage = require('../messages/TwilioStatusCallbackMessage');
 const Queue = require('./Queue');
 
 class MocoMessageDataQ extends Queue {
   constructor(...args) {
     super(...args);
-    this.messageClass = TwillioStatusCallbackMessage;
+    this.messageClass = TwilioStatusCallbackMessage;
   }
 }
 

--- a/src/queues/TwilioSmsBroadcastGambitRelayQ.js
+++ b/src/queues/TwilioSmsBroadcastGambitRelayQ.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const TwillioStatusCallbackMessage = require('../messages/TwillioStatusCallbackMessage');
+const Queue = require('./Queue');
+
+class TwilioSmsBroadcastGambitRelayQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.messageClass = TwillioStatusCallbackMessage;
+    this.routes.push('sms-broadcast.status-callback.twilio.webhook');
+  }
+}
+
+module.exports = TwilioSmsBroadcastGambitRelayQ;

--- a/src/queues/TwilioSmsBroadcastGambitRelayQ.js
+++ b/src/queues/TwilioSmsBroadcastGambitRelayQ.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const TwillioStatusCallbackMessage = require('../messages/TwillioStatusCallbackMessage');
+const TwilioStatusCallbackMessage = require('../messages/TwilioStatusCallbackMessage');
 const Queue = require('./Queue');
 
 class TwilioSmsBroadcastGambitRelayQ extends Queue {
   constructor(...args) {
     super(...args);
-    this.messageClass = TwillioStatusCallbackMessage;
+    this.messageClass = TwilioStatusCallbackMessage;
     this.routes.push('sms-broadcast.status-callback.twilio.webhook');
   }
 }

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -3,7 +3,7 @@
 const CustomerIoWebhookMessage = require('../../messages/CustomerIoWebhookMessage');
 const FreeFormMessage = require('../../messages/FreeFormMessage');
 const MdataMessage = require('../../messages/MdataMessage');
-const TwillioStatusCallbackMessage = require('../../messages/TwillioStatusCallbackMessage');
+const TwilioStatusCallbackMessage = require('../../messages/TwilioStatusCallbackMessage');
 const WebController = require('./WebController');
 
 class WebHooksWebController extends WebController {
@@ -52,7 +52,7 @@ class WebHooksWebController extends WebController {
 
   async mocoMessageData(ctx) {
     try {
-      // Todo: looks like I should have used TwillioStatusCallbackMessage here.
+      // Todo: looks like I should have used TwilioStatusCallbackMessage here.
       const freeFormMessage = FreeFormMessage.fromCtx(ctx);
       freeFormMessage.validate();
       const { mocoMessageDataQ } = this.blink.queues;
@@ -65,7 +65,7 @@ class WebHooksWebController extends WebController {
 
   async twilioSmsBroadcast(ctx) {
     try {
-      const message = TwillioStatusCallbackMessage.fromCtx(ctx);
+      const message = TwilioStatusCallbackMessage.fromCtx(ctx);
       message.validate();
       this.blink.exchange.publish(
         'sms-broadcast.status-callback.twilio.webhook',
@@ -73,7 +73,7 @@ class WebHooksWebController extends WebController {
       );
 
 
-      // TODO: check if this response is ok with twillio
+      // TODO: check if this response is ok with twilio
       // @see https://www.twilio.com/docs/api/twiml/sms/your_response#status-callbacks
       //
       // Quote:

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -65,7 +65,6 @@ class WebHooksWebController extends WebController {
 
   async twilioSmsBroadcast(ctx) {
     try {
-      // Todo: validate and save braodcast metadata
       const message = TwillioStatusCallbackMessage.fromCtx(ctx);
       message.validate();
       this.blink.exchange.publish(

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -3,6 +3,7 @@
 const CustomerIoWebhookMessage = require('../../messages/CustomerIoWebhookMessage');
 const FreeFormMessage = require('../../messages/FreeFormMessage');
 const MdataMessage = require('../../messages/MdataMessage');
+const TwillioStatusCallbackMessage = require('../../messages/TwillioStatusCallbackMessage');
 const WebController = require('./WebController');
 
 class WebHooksWebController extends WebController {
@@ -13,6 +14,7 @@ class WebHooksWebController extends WebController {
     this.customerioEmailActivity = this.customerioEmailActivity.bind(this);
     this.gambitChatbotMdata = this.gambitChatbotMdata.bind(this);
     this.mocoMessageData = this.mocoMessageData.bind(this);
+    this.twilioSmsBroadcast = this.twilioSmsBroadcast.bind(this);
   }
 
   async index(ctx) {
@@ -20,6 +22,7 @@ class WebHooksWebController extends WebController {
       'customerio-email-activity': this.fullUrl('api.v1.webhooks.customerio-email-activity'),
       'gambit-chatbot-mdata': this.fullUrl('api.v1.webhooks.gambit-chatbot-mdata'),
       'moco-message-data': this.fullUrl('api.v1.webhooks.moco-message-data'),
+      'twilio-sms-broadcast': this.fullUrl('api.v1.webhooks.twilio-sms-broadcast'),
     };
   }
 
@@ -49,11 +52,27 @@ class WebHooksWebController extends WebController {
 
   async mocoMessageData(ctx) {
     try {
+      // Todo: looks like I should have used TwillioStatusCallbackMessage here.
       const freeFormMessage = FreeFormMessage.fromCtx(ctx);
       freeFormMessage.validate();
       const { mocoMessageDataQ } = this.blink.queues;
       mocoMessageDataQ.publish(freeFormMessage);
       this.sendOK(ctx, freeFormMessage);
+    } catch (error) {
+      this.sendError(ctx, error);
+    }
+  }
+
+  async twilioSmsBroadcast(ctx) {
+    try {
+      // Todo: validate and save braodcast metadata
+      const message = TwillioStatusCallbackMessage.fromCtx(ctx);
+      message.validate();
+      this.blink.exchange.publish(
+        'sms-broadcast.status-callback.twilio.webhook',
+        message,
+      );
+      this.sendOK(ctx, message);
     } catch (error) {
       this.sendError(ctx, error);
     }

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -71,6 +71,16 @@ class WebHooksWebController extends WebController {
         'sms-broadcast.status-callback.twilio.webhook',
         message,
       );
+
+
+      // TODO: check if this response is ok with twillio
+      // @see https://www.twilio.com/docs/api/twiml/sms/your_response#status-callbacks
+      //
+      // Quote:
+      // It's recommended that you respond to status callbacks with either a
+      // 204 No Content or a 200 OK with Content-Type: text/xml
+      // and an empty <Response/> in the body.
+      // Failure to respond properly will result in warnings in Debugger.
       this.sendOK(ctx, message);
     } catch (error) {
       this.sendError(ctx, error);

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -11,7 +11,7 @@ const CampaignSignupMessage = require('../../src/messages/CampaignSignupMessage'
 const CampaignSignupPostMessage = require('../../src/messages/CampaignSignupPostMessage');
 const CustomerIoUpdateCustomerMessage = require('../../src/messages/CustomerIoUpdateCustomerMessage');
 const MdataMessage = require('../../src/messages/MdataMessage');
-const TwillioStatusCallbackMessage = require('../../src/messages/TwillioStatusCallbackMessage');
+const TwilioStatusCallbackMessage = require('../../src/messages/TwilioStatusCallbackMessage');
 const UserMessage = require('../../src/messages/UserMessage');
 
 // ------- Init ----------------------------------------------------------------
@@ -153,7 +153,7 @@ class MessageFactoryHelper {
   static getValidMessageData() {
     // TODO: randomize
     const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
-    return new TwillioStatusCallbackMessage({
+    return new TwilioStatusCallbackMessage({
       data: {
         ToCountry: 'US',
         MediaContentType0: 'image/png',

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -235,7 +235,7 @@ test('POST /api/v1/webhooks/twilio-sms-broadcast should publish message to twili
   const broadcastId = chance.word();
 
   const res = await t.context.supertest.post('/api/v1/webhooks/twilio-sms-broadcast')
-    .query({ broadcast_id: broadcastId })
+    .query({ broadcastId })
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send(data);
 
@@ -262,7 +262,7 @@ test('POST /api/v1/webhooks/twilio-sms-broadcast should publish message to twili
   // Check broadcast id.
   messageData.should.have.property('meta');
   messageData.meta.should.have.property('query');
-  messageData.meta.query.should.have.property('broadcast_id', broadcastId);
+  messageData.meta.query.should.have.property('broadcastId', broadcastId);
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -2,8 +2,9 @@
 
 // ------- Imports -------------------------------------------------------------
 
-const test = require('ava');
 const chai = require('chai');
+const Chance = require('chance');
+const test = require('ava');
 
 const RabbitManagement = require('../../../src/lib/RabbitManagement');
 const HooksHelper = require('../../helpers/HooksHelper');
@@ -13,6 +14,8 @@ const HooksHelper = require('../../helpers/HooksHelper');
 chai.should();
 test.beforeEach(HooksHelper.startBlinkWebApp);
 test.afterEach(HooksHelper.stopBlinkWebApp);
+
+const chance = new Chance();
 
 // ------- Tests ---------------------------------------------------------------
 
@@ -229,7 +232,10 @@ test('POST /api/v1/webhooks/twilio-sms-broadcast should publish message to twili
     },
   };
 
+  const broadcastId = chance.word();
+
   const res = await t.context.supertest.post('/api/v1/webhooks/twilio-sms-broadcast')
+    .query({ broadcast_id: broadcastId })
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send(data);
 
@@ -252,6 +258,11 @@ test('POST /api/v1/webhooks/twilio-sms-broadcast should publish message to twili
   const messageData = JSON.parse(payload);
   messageData.should.have.property('data');
   messageData.data.should.be.eql(data);
+
+  // Check broadcast id.
+  messageData.should.have.property('meta');
+  messageData.meta.should.have.property('query');
+  messageData.meta.query.should.have.property('broadcast_id', broadcastId);
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -30,12 +30,18 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
   res.header['content-type'].should.match(/json/);
 
   // Check response.
+  // TODO: check in loop or use .equal()?
   res.body.should.have.property('customerio-email-activity')
     .and.have.string('/api/v1/webhooks/customerio-email-activity');
+
   res.body.should.have.property('gambit-chatbot-mdata')
     .and.have.string('/api/v1/webhooks/gambit-chatbot-mdata');
+
   res.body.should.have.property('moco-message-data')
     .and.have.string('/api/v1/webhooks/moco-message-data');
+
+  res.body.should.have.property('twilio-sms-broadcast')
+    .and.have.string('/api/v1/webhooks/twilio-sms-broadcast');
 });
 
 /**
@@ -203,6 +209,42 @@ test('POST /api/v1/webhooks/moco-message-data should publish message to moco-mes
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);
   // TODO: queue cleanup to make sure that it's not OLD message.
   const messages = await rabbit.getMessagesFrom('moco-message-data', 1);
+  messages.should.be.an('array').and.to.have.lengthOf(1);
+
+  messages[0].should.have.property('payload');
+  const payload = messages[0].payload;
+  const messageData = JSON.parse(payload);
+  messageData.should.have.property('data');
+  messageData.data.should.be.eql(data);
+});
+
+/**
+ * POST /api/v1/webhooks/twilio-sms-broadcast
+ */
+test('POST /api/v1/webhooks/twilio-sms-broadcast should publish message to twilio-sms-broadcast-gambit-relay queue', async (t) => {
+  const data = {
+    random: 'key',
+    nested: {
+      random2: 'key2',
+    },
+  };
+
+  const res = await t.context.supertest.post('/api/v1/webhooks/twilio-sms-broadcast')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(202);
+
+  // Check response to be json
+  res.header.should.have.property('content-type');
+  res.header['content-type'].should.match(/json/);
+
+  // Check response.
+  res.body.should.have.property('ok', true);
+
+  // Check that the message is queued.
+  const rabbit = new RabbitManagement(t.context.config.amqpManagement);
+  const messages = await rabbit.getMessagesFrom('twilio-sms-broadcast-gambit-relay', 1, false);
   messages.should.be.an('array').and.to.have.lengthOf(1);
 
   messages[0].should.have.property('payload');


### PR DESCRIPTION
#### What's this PR do?
- Creates `/api/v1/webhooks/twilio-sms-broadcast` webhook
- Creates `twilio-sms-broadcast-gambit-relay` queue
- Saves StatusCallback data from `/api/v1/webhooks/twilio-sms-broadcast` webhook to `twilio-sms-broadcast-gambit-relay`
- Extends `TwilioStatusCallbackMessage` metadata with GET querystring to catch broadcast id

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### What are the relevant tickets?
Pivotal [#151266069](https://www.pivotaltracker.com/story/show/000000000)
Ref https://github.com/DoSomething/gambit-conversations/pull/141