### PR TITLE
[#151266069] Gambit broadcast relay worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -5,3 +5,4 @@ customer-io-update-customer: npm run worker customer-io-update-customer
 customer-io-campaign-signup: npm run worker customer-io-campaign-signup
 customer-io-campaign-signup-post: npm run worker customer-io-campaign-signup-post
 gambit-message-data-relay: npm run worker gambit-message-data-relay
+twilio-sms-broadcast-gambit-relay: npm run worker twilio-sms-broadcast-gambit-relay

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const BlinkError = require('../errors/BlinkError');
-const CustomerIoCampaignSignupWorker = require('../workers/CustomerIoCampaignSignupWorker');
 const CustomerIoCampaignSignupPostWorker = require('../workers/CustomerIoCampaignSignupPostWorker');
+const CustomerIoCampaignSignupWorker = require('../workers/CustomerIoCampaignSignupWorker');
 const CustomerIoUpdateCustomerWorker = require('../workers/CustomerIoUpdateCustomerWorker');
 const FetchWorker = require('../workers/FetchWorker');
 const GambitChatbotMdataProxyWorker = require('../workers/GambitChatbotMdataProxyWorker');
 const GambitMessageDataRelayWorker = require('../workers/GambitMessageDataRelayWorker');
+const TwilioSmsBroadcastGambitRelayWorker = require('../workers/TwilioSmsBroadcastGambitRelayWorker');
 const BlinkApp = require('./BlinkApp');
 
 class BlinkWorkerApp extends BlinkApp {
@@ -38,6 +39,7 @@ class BlinkWorkerApp extends BlinkApp {
       'customer-io-campaign-signup-post': CustomerIoCampaignSignupPostWorker,
       'gambit-chatbot-mdata-proxy': GambitChatbotMdataProxyWorker,
       'gambit-message-data-relay': GambitMessageDataRelayWorker,
+      'twilio-sms-broadcast-gambit-relay': TwilioSmsBroadcastGambitRelayWorker,
     };
   }
 }

--- a/src/messages/TwilioStatusCallbackMessage.js
+++ b/src/messages/TwilioStatusCallbackMessage.js
@@ -18,6 +18,10 @@ class TwilioStatusCallbackMessage extends Message {
     return this.getData().SmsStatus === 'received';
   }
 
+  isDelivered() {
+    return this.getData().MessageStatus === 'delivered';
+  }
+
   static fromCtx(ctx) {
     // TODO: save more metadata
     // TODO: metadata parse helper

--- a/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
+++ b/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
@@ -40,8 +40,8 @@ class TwilioSmsBroadcastGambitRelayWorker extends Worker {
     // Check that the message has broadcastId query string.
     // If it hasn't, something is wrong. We expect broadcastId to be
     // provided with all reciepts.
-    const meta = message.getMeta();
-    if (!meta.query || !meta.query.broadcastId) {
+    const query = message.getMeta().query;
+    if (!query || !query.broadcastId) {
       const meta = {
         env: this.blink.config.app.env,
         code: 'error_gambit_broadcast_relay_missing_broadcastId',
@@ -54,7 +54,7 @@ class TwilioSmsBroadcastGambitRelayWorker extends Worker {
 
     const headers = this.getRequestHeaders(message);
     const response = await fetch(
-      `${this.baseURL}/import-message?broadcastId=${meta.query.broadcastId}`,
+      `${this.baseURL}/import-message?broadcastId=${query.broadcastId}`,
       {
         method: 'POST',
         headers,

--- a/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
+++ b/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
@@ -54,7 +54,7 @@ class TwilioSmsBroadcastGambitRelayWorker extends Worker {
 
     const headers = this.getRequestHeaders(message);
     const response = await fetch(
-      `${this.baseURL}/import-message`,
+      `${this.baseURL}/import-message?broadcastId=${meta.query.broadcastId}`,
       {
         method: 'POST',
         headers,

--- a/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
+++ b/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
@@ -39,7 +39,7 @@ class TwilioSmsBroadcastGambitRelayWorker extends Worker {
 
     // Check that the message has broadcastId query string.
     // If it hasn't, something is wrong. We expect broadcastId to be
-    // provided with all reciepts.
+    // provided with all receipts.
     const query = message.getMeta().query;
     if (!query || !query.broadcastId) {
       const meta = {

--- a/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
+++ b/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const fetch = require('node-fetch');
+const logger = require('winston');
+
+const BlinkRetryError = require('../errors/BlinkRetryError');
+const Worker = require('./Worker');
+
+class TwilioSmsBroadcastGambitRelayWorker extends Worker {
+  constructor(blink) {
+    super(blink);
+    this.blink = blink;
+
+    this.baseURL = this.blink.config.gambit.converationsBaseUrl;
+    this.apiKey = this.blink.config.gambit.converationsApiKey;
+
+    // Bind process method to queue context
+    this.consume = this.consume.bind(this);
+  }
+
+  setup() {
+    this.queue = this.blink.queues.twilioSmsBroadcastGambitRelayQ;
+  }
+
+  async consume(message) {
+    const body = JSON.stringify(message.getData());
+
+    // Send only delivered messages to Gambit Conversations import.
+    if (TwilioSmsBroadcastGambitRelayWorker.shouldSkip(message)) {
+      const meta = {
+        env: this.blink.config.app.env,
+        code: 'success_gambit_broadcast_relay_expected_skip',
+        worker: this.constructor.name,
+        request_id: message ? message.getRequestId() : 'not_parsed',
+      };
+      logger.log('debug', body, meta);
+      return true;
+    }
+
+    // Check that the message has broadcastId query string.
+    // If it hasn't, something is wrong. We expect broadcastId to be
+    // provided with all reciepts.
+    const meta = message.getMeta();
+    if (!meta.query || !meta.query.broadcastId) {
+      const meta = {
+        env: this.blink.config.app.env,
+        code: 'error_gambit_broadcast_relay_missing_broadcastId',
+        worker: this.constructor.name,
+        request_id: message ? message.getRequestId() : 'not_parsed',
+      };
+      logger.log('warning', body, meta);
+      return true;
+    }
+
+    const headers = this.getRequestHeaders(message);
+    const response = await fetch(
+      `${this.baseURL}/import-message`,
+      {
+        method: 'POST',
+        headers,
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      this.log(
+        'debug',
+        message,
+        response,
+        'success_gambit_broadcast_relay_response_200',
+      );
+      return true;
+    }
+
+    if (this.checkRetrySuppress(response)) {
+      this.log(
+        'debug',
+        message,
+        response,
+        'success_gambit_broadcast_relay_retry_suppress',
+      );
+      return true;
+    }
+
+    if (response.status === 422) {
+      this.log(
+        'warning',
+        message,
+        response,
+        'error_gambit_broadcast_relay_response_422',
+      );
+      return false;
+    }
+
+
+    this.log(
+      'warning',
+      message,
+      response,
+      'error_gambit_broadcast_relay_response_not_200_retry',
+    );
+
+    throw new BlinkRetryError(
+      `${response.status} ${response.statusText}`,
+      message,
+    );
+  }
+
+  async log(level, message, response, code = 'unexpected_code') {
+    const cleanedBody = (await response.text()).replace(/\n/g, '\\n');
+
+    const meta = {
+      env: this.blink.config.app.env,
+      code,
+      worker: this.constructor.name,
+      request_id: message ? message.getRequestId() : 'not_parsed',
+      response_status: response.status,
+      response_status_text: `"${response.statusText}"`,
+    };
+    // Todo: log error?
+    logger.log(level, cleanedBody, meta);
+  }
+
+  getRequestHeaders(message) {
+    const headers = {
+      Authorization: `Basic ${this.apiKey}`,
+      'X-Request-ID': message.getRequestId(),
+      'Content-type': 'application/json',
+    };
+
+    if (message.getMeta().retry && message.getMeta().retry > 0) {
+      headers['x-blink-retry-count'] = message.getMeta().retry;
+    }
+
+    return headers;
+  }
+
+  checkRetrySuppress(response) {
+    // TODO: create common helper
+    const headerResult = response.headers.get(this.blink.config.app.retrySuppressHeader);
+    if (!headerResult) {
+      return false;
+    }
+    return headerResult.toLowerCase() === 'true';
+  }
+
+  static shouldSkip(message) {
+    return !message.isDelivered();
+  }
+}
+
+module.exports = TwilioSmsBroadcastGambitRelayWorker;

--- a/test/workers/TwilioSmsBroadcastGambitRelayWorker.test.js
+++ b/test/workers/TwilioSmsBroadcastGambitRelayWorker.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const chai = require('chai');
+const fetch = require('node-fetch');
+const test = require('ava');
+
+const BlinkWorkerApp = require('../../src/app/BlinkWorkerApp');
+const TwilioSmsBroadcastGambitRelayWorker = require('../../src/workers/TwilioSmsBroadcastGambitRelayWorker');
+const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+const { Response } = fetch;
+
+// ------- Tests ---------------------------------------------------------------
+
+test('Gambit Broadcast relay should recieve correct retry count if message has been retried', () => {
+  const config = require('../../config');
+  const gambitWorkerApp = new BlinkWorkerApp(config, 'twilio-sms-broadcast-gambit-relay');
+  const gambitWorker = gambitWorkerApp.worker;
+
+  // No retry property:
+  gambitWorker.getRequestHeaders(MessageFactoryHelper.getValidMessageData())
+    .should.not.have.property('x-blink-retry-count');
+
+  // retry = 0
+  const retriedZero = MessageFactoryHelper.getValidMessageData();
+  retriedZero.payload.meta.retry = 0;
+  gambitWorker.getRequestHeaders(retriedZero)
+    .should.not.have.property('x-blink-retry-count');
+
+  // retry = 1
+  const retriedOnce = MessageFactoryHelper.getValidMessageData();
+  retriedOnce.payload.meta.retry = 1;
+  gambitWorker.getRequestHeaders(retriedOnce)
+    .should.have.property('x-blink-retry-count').and.equal(1);
+});
+
+
+test('Test Gambit response with x-blink-retry-suppress header', () => {
+  const config = require('../../config');
+  const gambitWorkerApp = new BlinkWorkerApp(config, 'twilio-sms-broadcast-gambit-relay');
+  const gambitWorker = gambitWorkerApp.worker;
+
+  // Gambit order retry suppression
+  const retrySuppressResponse = new Response(
+    'Unknown Gambit error',
+    {
+      status: 422,
+      statusText: 'Unknown Gambit error',
+      headers: {
+        // Also make sure that blink recongnizes non standart header case
+        'X-BlInK-RetRY-SuPPRESS': 'TRUE',
+      },
+    },
+  );
+
+  gambitWorker.checkRetrySuppress(retrySuppressResponse).should.be.true;
+
+
+  // Normal Gambit 422 response
+  const normalFailedResponse = new Response(
+    'Unknown Gambit error',
+    {
+      status: 422,
+      statusText: 'Unknown Gambit error',
+      headers: {
+        'x-taco-count': 'infinity',
+      },
+    },
+  );
+  gambitWorker.checkRetrySuppress(normalFailedResponse).should.be.false;
+});
+
+test('Gambit should process delivered messages', () => {
+  const messageData = MessageFactoryHelper.getValidMessageData();
+  messageData.payload.data.MessageStatus = 'delivered';
+  TwilioSmsBroadcastGambitRelayWorker.shouldSkip(messageData).should.be.false;
+});
+
+test('Gambit should not process not inbound messages', () => {
+  const messageData = MessageFactoryHelper.getValidMessageData();
+  messageData.payload.data.MessageStatus = 'other';
+  TwilioSmsBroadcastGambitRelayWorker.shouldSkip(messageData).should.be.true;
+});
+
+// ------- End -----------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
-Creates Gambit broadcast relay worker that passes 'delivered' StatusCallback messages that have `broadcastId` from Twilio to Gambit Conversations `/import-message`.

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn web`
- `yarn worker twilio-sms-broadcast-gambit-relay`
- Send curl request:

```
curl -X POST \
  'http://localhost:5050/api/v1/webhooks/twilio-sms-broadcast?broadcastId=blink-test' \
  -H 'authorization: Basic Ymxpbms6Ymxpbms=' \
  -H 'content-type: application/json' \
  -d '{
  "To": "+15552222222",
  "Body": "Boost a stranger'\'''\''s self-esteem with just a sticky note! \n\nWant to join Mirror Messages?\n\nYes or No",
  "MessageStatus": "delivered",
  "MessageSid": "SMXXX"
}'
```
- Notice worker logs. It should retry, as broadcastId is not defined

#### What are the relevant tickets?
Pivotal [#151266069](https://www.pivotaltracker.com/story/show/151266069)
Ref #138
Ref https://github.com/DoSomething/gambit-conversations/pull/141