### PR TITLE
[#151620532] Implement /twilio-sms-inbound webhook for GamCon inbound sms relay

### DIFF
--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -13,6 +13,7 @@ const GambitChatbotMdataQ = require('../queues/GambitChatbotMdataQ');
 const MocoMessageDataQ = require('../queues/MocoMessageDataQ');
 const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
 const TwilioSmsBroadcastGambitRelayQ = require('../queues/TwilioSmsBroadcastGambitRelayQ');
+const TwilioSmsInboundGambitRelayQ = require('../queues/TwilioSmsInboundGambitRelayQ');
 
 class BlinkApp {
   constructor(config) {
@@ -54,6 +55,7 @@ class BlinkApp {
         MocoMessageDataQ,
         QuasarCustomerIoEmailActivityQ,
         TwilioSmsBroadcastGambitRelayQ,
+        TwilioSmsInboundGambitRelayQ,
       ]);
     } catch (error) {
       this.connecting = false;

--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -93,6 +93,11 @@ class BlinkWebApp extends BlinkApp {
       '/api/v1/webhooks/twilio-sms-broadcast',
       webHooksWebController.twilioSmsBroadcast,
     );
+    router.post(
+      'api.v1.webhooks.twilio-sms-inbound',
+      '/api/v1/webhooks/twilio-sms-inbound',
+      webHooksWebController.twilioSmsInbound,
+    );
     return router;
   }
 

--- a/src/queues/TwilioSmsBroadcastGambitRelayQ.js
+++ b/src/queues/TwilioSmsBroadcastGambitRelayQ.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const TwilioStatusCallbackMessage = require('../messages/TwilioStatusCallbackMessage');
+const FreeFormMessage = require('../messages/FreeFormMessage');
 const Queue = require('./Queue');
 
-class TwilioSmsBroadcastGambitRelayQ extends Queue {
+class TwilioSmsInboundGambitRelayQ extends Queue {
   constructor(...args) {
     super(...args);
-    this.messageClass = TwilioStatusCallbackMessage;
-    this.routes.push('sms-broadcast.status-callback.twilio.webhook');
+    this.messageClass = FreeFormMessage;
+    this.routes.push('sms-inbound.twilio.webhook');
   }
 }
 
-module.exports = TwilioSmsBroadcastGambitRelayQ;
+module.exports = TwilioSmsInboundGambitRelayQ;

--- a/src/queues/TwilioSmsBroadcastGambitRelayQ.js
+++ b/src/queues/TwilioSmsBroadcastGambitRelayQ.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const FreeFormMessage = require('../messages/FreeFormMessage');
+const TwilioStatusCallbackMessage = require('../messages/TwilioStatusCallbackMessage');
 const Queue = require('./Queue');
 
-class TwilioSmsInboundGambitRelayQ extends Queue {
+class TwilioSmsBroadcastGambitRelayQ extends Queue {
   constructor(...args) {
     super(...args);
-    this.messageClass = FreeFormMessage;
-    this.routes.push('sms-inbound.twilio.webhook');
+    this.messageClass = TwilioStatusCallbackMessage;
+    this.routes.push('sms-broadcast.status-callback.twilio.webhook');
   }
 }
 
-module.exports = TwilioSmsInboundGambitRelayQ;
+module.exports = TwilioSmsBroadcastGambitRelayQ;

--- a/src/queues/TwilioSmsInboundGambitRelayQ.js
+++ b/src/queues/TwilioSmsInboundGambitRelayQ.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const FreeFormMessage = require('../messages/FreeFormMessage');
+const Queue = require('./Queue');
+
+class TwilioSmsInboundGambitRelayQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.messageClass = FreeFormMessage;
+    this.routes.push('sms-inbound.twilio.webhook');
+  }
+}
+
+module.exports = TwilioSmsInboundGambitRelayQ;

--- a/src/web/controllers/WebController.js
+++ b/src/web/controllers/WebController.js
@@ -38,7 +38,13 @@ class WebController {
     };
     // Accepted.
     ctx.status = status;
-    this.log('info', ctx, message);
+    this.log('info', ctx, message, ctx.body.code);
+  }
+
+  sendOKNoContent(ctx, message, status = 204) {
+    ctx.body = '';
+    ctx.status = status;
+    this.log('info', ctx, message, 'success_message_queued');
   }
 
   sendError(ctx, error) {
@@ -61,17 +67,17 @@ class WebController {
     }
     ctx.body.message = error.toString();
 
-    this.log(level, ctx);
+    this.log(level, ctx, false, ctx.body.code);
   }
 
-  log(level, ctx, message) {
-    let text = ctx.body.message;
+  log(level, ctx, message, code) {
+    let text = ctx.body ? ctx.body.message : undefined;
     if (message) {
       text = `${text}, message ${message.toString()}`;
     }
     const meta = {
       env: this.blink.config.app.env,
-      code: ctx.body.code || 'unexpected_code',
+      code,
       request_id: ctx.id,
       method: ctx.request.method,
       host: ctx.request.hostname,

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -15,6 +15,7 @@ class WebHooksWebController extends WebController {
     this.gambitChatbotMdata = this.gambitChatbotMdata.bind(this);
     this.mocoMessageData = this.mocoMessageData.bind(this);
     this.twilioSmsBroadcast = this.twilioSmsBroadcast.bind(this);
+    this.twilioSmsInbound = this.twilioSmsInbound.bind(this);
   }
 
   async index(ctx) {
@@ -23,6 +24,7 @@ class WebHooksWebController extends WebController {
       'gambit-chatbot-mdata': this.fullUrl('api.v1.webhooks.gambit-chatbot-mdata'),
       'moco-message-data': this.fullUrl('api.v1.webhooks.moco-message-data'),
       'twilio-sms-broadcast': this.fullUrl('api.v1.webhooks.twilio-sms-broadcast'),
+      'twilio-sms-inbound': this.fullUrl('api.v1.webhooks.twilio-sms-inbound'),
     };
   }
 
@@ -58,6 +60,20 @@ class WebHooksWebController extends WebController {
       const { mocoMessageDataQ } = this.blink.queues;
       mocoMessageDataQ.publish(freeFormMessage);
       this.sendOK(ctx, freeFormMessage);
+    } catch (error) {
+      this.sendError(ctx, error);
+    }
+  }
+
+  async twilioSmsInbound(ctx) {
+    try {
+      const message = FreeFormMessage.fromCtx(ctx);
+      message.validate();
+      this.blink.exchange.publish(
+        'sms-inbound.twilio.webhook',
+        message,
+      );
+      this.sendOK(ctx, message);
     } catch (error) {
       this.sendError(ctx, error);
     }

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -73,7 +73,7 @@ class WebHooksWebController extends WebController {
         'sms-inbound.twilio.webhook',
         message,
       );
-      this.sendOK(ctx, message);
+      this.sendOKNoContent(ctx, message);
     } catch (error) {
       this.sendError(ctx, error);
     }

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -73,6 +73,7 @@ class WebHooksWebController extends WebController {
         'sms-inbound.twilio.webhook',
         message,
       );
+      // See https://www.twilio.com/docs/api/twiml/sms/your_response.
       this.sendOKNoContent(ctx, message);
     } catch (error) {
       this.sendError(ctx, error);
@@ -87,17 +88,8 @@ class WebHooksWebController extends WebController {
         'sms-broadcast.status-callback.twilio.webhook',
         message,
       );
-
-
-      // TODO: check if this response is ok with twilio
-      // @see https://www.twilio.com/docs/api/twiml/sms/your_response#status-callbacks
-      //
-      // Quote:
-      // It's recommended that you respond to status callbacks with either a
-      // 204 No Content or a 200 OK with Content-Type: text/xml
-      // and an empty <Response/> in the body.
-      // Failure to respond properly will result in warnings in Debugger.
-      this.sendOK(ctx, message);
+      // See https://www.twilio.com/docs/api/twiml/sms/your_response.
+      this.sendOKNoContent(ctx, message);
     } catch (error) {
       this.sendError(ctx, error);
     }

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -286,14 +286,11 @@ test('POST /api/v1/webhooks/twilio-sms-inbound should publish message to twilio-
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send(data);
 
-  res.status.should.be.equal(202);
-
-  // Check response to be json
-  res.header.should.have.property('content-type');
-  res.header['content-type'].should.match(/json/);
-
-  // Check response.
-  res.body.should.have.property('ok', true);
+  // Ensure TwiML compatible response.
+  res.status.should.be.equal(204);
+  res.res.statusMessage.toLowerCase().should.equal('no content');
+  res.header.should.not.have.property('content-type');
+  res.text.should.equal('');
 
   // Check that the message is queued.
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -242,14 +242,11 @@ test('POST /api/v1/webhooks/twilio-sms-broadcast should publish message to twili
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send(data);
 
-  res.status.should.be.equal(202);
-
-  // Check response to be json
-  res.header.should.have.property('content-type');
-  res.header['content-type'].should.match(/json/);
-
-  // Check response.
-  res.body.should.have.property('ok', true);
+  // Ensure TwiML compatible response.
+  res.status.should.be.equal(204);
+  res.res.statusMessage.toLowerCase().should.equal('no content');
+  res.header.should.not.have.property('content-type');
+  res.text.should.equal('');
 
   // Check that the message is queued.
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -45,6 +45,9 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
 
   res.body.should.have.property('twilio-sms-broadcast')
     .and.have.string('/api/v1/webhooks/twilio-sms-broadcast');
+
+  res.body.should.have.property('twilio-sms-inbound')
+    .and.have.string('/api/v1/webhooks/twilio-sms-inbound');
 });
 
 /**
@@ -263,6 +266,45 @@ test('POST /api/v1/webhooks/twilio-sms-broadcast should publish message to twili
   messageData.should.have.property('meta');
   messageData.meta.should.have.property('query');
   messageData.meta.query.should.have.property('broadcastId', broadcastId);
+});
+
+/**
+ * POST /api/v1/webhooks/twilio-sms-inbound
+ */
+test('POST /api/v1/webhooks/twilio-sms-inbound should publish message to twilio-sms-inbound-gambit-relay queue', async (t) => {
+  const data = {
+    random: 'key',
+    nested: {
+      random2: 'key2',
+    },
+  };
+
+  const broadcastId = chance.word();
+
+  const res = await t.context.supertest.post('/api/v1/webhooks/twilio-sms-inbound')
+    .query({ broadcastId })
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(202);
+
+  // Check response to be json
+  res.header.should.have.property('content-type');
+  res.header['content-type'].should.match(/json/);
+
+  // Check response.
+  res.body.should.have.property('ok', true);
+
+  // Check that the message is queued.
+  const rabbit = new RabbitManagement(t.context.config.amqpManagement);
+  const messages = await rabbit.getMessagesFrom('twilio-sms-inbound-gambit-relay', 1, false);
+  messages.should.be.an('array').and.to.have.lengthOf(1);
+
+  messages[0].should.have.property('payload');
+  const payload = messages[0].payload;
+  const messageData = JSON.parse(payload);
+  messageData.should.have.property('data');
+  messageData.data.should.be.eql(data);
 });
 
 // ------- End -----------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
- Creates `/api/v1/webhooks/twilio-sms-inbound` to relay inbound sms traffic to Gambit Conversation's `/revieve-message`
- Created new helper function `WebController.sendOKNoContent()` that sends `204 No Content` which is usefull TwiML responses with no body
- Used `WebController.sendOKNoContent()` to reply to Twilio Status Callback and Inbound SMS webhooks

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### What are the relevant tickets?
Pivotal [151620532](https://www.pivotaltracker.com/story/show/151620532)