### PR TITLE
[#151620532] Implements Gambit inbound sms relay

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -6,3 +6,4 @@ customer-io-campaign-signup: npm run worker customer-io-campaign-signup
 customer-io-campaign-signup-post: npm run worker customer-io-campaign-signup-post
 gambit-message-data-relay: npm run worker gambit-message-data-relay
 twilio-sms-broadcast-gambit-relay: npm run worker twilio-sms-broadcast-gambit-relay
+twilio-sms-inbound-gambit-relay: npm run worker twilio-sms-inbound-gambit-relay

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -8,6 +8,7 @@ const FetchWorker = require('../workers/FetchWorker');
 const GambitChatbotMdataProxyWorker = require('../workers/GambitChatbotMdataProxyWorker');
 const GambitMessageDataRelayWorker = require('../workers/GambitMessageDataRelayWorker');
 const TwilioSmsBroadcastGambitRelayWorker = require('../workers/TwilioSmsBroadcastGambitRelayWorker');
+const TwilioSmsInboundGambitRelayWorker = require('../workers/TwilioSmsInboundGambitRelayWorker');
 const BlinkApp = require('./BlinkApp');
 
 class BlinkWorkerApp extends BlinkApp {
@@ -40,6 +41,7 @@ class BlinkWorkerApp extends BlinkApp {
       'gambit-chatbot-mdata-proxy': GambitChatbotMdataProxyWorker,
       'gambit-message-data-relay': GambitMessageDataRelayWorker,
       'twilio-sms-broadcast-gambit-relay': TwilioSmsBroadcastGambitRelayWorker,
+      'twilio-sms-inbound-gambit-relay': TwilioSmsInboundGambitRelayWorker,
     };
   }
 }

--- a/src/workers/TwilioSmsInboundGambitRelayWorker.js
+++ b/src/workers/TwilioSmsInboundGambitRelayWorker.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const fetch = require('node-fetch');
+const logger = require('winston');
+
+const BlinkRetryError = require('../errors/BlinkRetryError');
+const Worker = require('./Worker');
+
+class TwilioSmsInboundGambitRelayWorker extends Worker {
+  constructor(blink) {
+    super(blink);
+    this.blink = blink;
+
+    this.baseURL = this.blink.config.gambit.converationsBaseUrl;
+    this.apiKey = this.blink.config.gambit.converationsApiKey;
+
+    // Bind process method to queue context
+    this.consume = this.consume.bind(this);
+  }
+
+  setup() {
+    this.queue = this.blink.queues.twilioSmsInboundGambitRelayQ;
+  }
+
+  async consume(message) {
+    const body = JSON.stringify(message.getData());
+    const headers = this.getRequestHeaders(message);
+    const response = await fetch(
+      `${this.baseURL}/receive-message`,
+      {
+        method: 'POST',
+        headers,
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      this.log(
+        'debug',
+        message,
+        response,
+        'success_gambit_inbound_relay_response_200',
+      );
+      return true;
+    }
+
+    if (this.checkRetrySuppress(response)) {
+      this.log(
+        'debug',
+        message,
+        response,
+        'success_gambit_inbound_relay_retry_suppress',
+      );
+      return true;
+    }
+
+    if (response.status === 422) {
+      this.log(
+        'warning',
+        message,
+        response,
+        'error_gambit_inbound_relay_response_422',
+      );
+      return false;
+    }
+
+
+    this.log(
+      'warning',
+      message,
+      response,
+      'error_gambit_inbound_relay_response_not_200_retry',
+    );
+
+    throw new BlinkRetryError(
+      `${response.status} ${response.statusText}`,
+      message,
+    );
+  }
+
+  async log(level, message, response, code = 'unexpected_code') {
+    const cleanedBody = (await response.text()).replace(/\n/g, '\\n');
+
+    const meta = {
+      env: this.blink.config.app.env,
+      code,
+      worker: this.constructor.name,
+      request_id: message ? message.getRequestId() : 'not_parsed',
+      response_status: response.status,
+      response_status_text: `"${response.statusText}"`,
+    };
+    // Todo: log error?
+    logger.log(level, cleanedBody, meta);
+  }
+
+  getRequestHeaders(message) {
+    const headers = {
+      Authorization: `Basic ${this.apiKey}`,
+      'X-Request-ID': message.getRequestId(),
+      'Content-type': 'application/json',
+    };
+
+    if (message.getMeta().retry && message.getMeta().retry > 0) {
+      headers['x-blink-retry-count'] = message.getMeta().retry;
+    }
+
+    return headers;
+  }
+}
+
+module.exports = TwilioSmsInboundGambitRelayWorker;

--- a/src/workers/TwilioSmsInboundGambitRelayWorker.js
+++ b/src/workers/TwilioSmsInboundGambitRelayWorker.js
@@ -106,6 +106,15 @@ class TwilioSmsInboundGambitRelayWorker extends Worker {
 
     return headers;
   }
+
+  checkRetrySuppress(response) {
+    // TODO: create common helper
+    const headerResult = response.headers.get(this.blink.config.app.retrySuppressHeader);
+    if (!headerResult) {
+      return false;
+    }
+    return headerResult.toLowerCase() === 'true';
+  }
 }
 
 module.exports = TwilioSmsInboundGambitRelayWorker;

--- a/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
+++ b/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
@@ -75,16 +75,4 @@ test('Test Gambit response with x-blink-retry-suppress header', () => {
   gambitWorker.checkRetrySuppress(normalFailedResponse).should.be.false;
 });
 
-test('Gambit should process delivered messages', () => {
-  const messageData = MessageFactoryHelper.getValidMessageData();
-  messageData.payload.data.MessageStatus = 'delivered';
-  TwilioSmsInboundGambitRelayWorker.shouldSkip(messageData).should.be.false;
-});
-
-test('Gambit should not process not inbound messages', () => {
-  const messageData = MessageFactoryHelper.getValidMessageData();
-  messageData.payload.data.MessageStatus = 'other';
-  TwilioSmsInboundGambitRelayWorker.shouldSkip(messageData).should.be.true;
-});
-
 // ------- End -----------------------------------------------------------------

--- a/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
+++ b/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
@@ -7,7 +7,6 @@ const fetch = require('node-fetch');
 const test = require('ava');
 
 const BlinkWorkerApp = require('../../src/app/BlinkWorkerApp');
-const TwilioSmsInboundGambitRelayWorker = require('../../src/workers/TwilioSmsInboundGambitRelayWorker');
 const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
 
 // ------- Init ----------------------------------------------------------------

--- a/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
+++ b/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const chai = require('chai');
+const fetch = require('node-fetch');
+const test = require('ava');
+
+const BlinkWorkerApp = require('../../src/app/BlinkWorkerApp');
+const TwilioSmsInboundGambitRelayWorker = require('../../src/workers/TwilioSmsInboundGambitRelayWorker');
+const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+const { Response } = fetch;
+
+// ------- Tests ---------------------------------------------------------------
+
+test('Gambit Broadcast relay should recieve correct retry count if message has been retried', () => {
+  const config = require('../../config');
+  const gambitWorkerApp = new BlinkWorkerApp(config, 'twilio-sms-inbound-gambit-relay');
+  const gambitWorker = gambitWorkerApp.worker;
+
+  // No retry property:
+  gambitWorker.getRequestHeaders(MessageFactoryHelper.getValidMessageData())
+    .should.not.have.property('x-blink-retry-count');
+
+  // retry = 0
+  const retriedZero = MessageFactoryHelper.getValidMessageData();
+  retriedZero.payload.meta.retry = 0;
+  gambitWorker.getRequestHeaders(retriedZero)
+    .should.not.have.property('x-blink-retry-count');
+
+  // retry = 1
+  const retriedOnce = MessageFactoryHelper.getValidMessageData();
+  retriedOnce.payload.meta.retry = 1;
+  gambitWorker.getRequestHeaders(retriedOnce)
+    .should.have.property('x-blink-retry-count').and.equal(1);
+});
+
+
+test('Test Gambit response with x-blink-retry-suppress header', () => {
+  const config = require('../../config');
+  const gambitWorkerApp = new BlinkWorkerApp(config, 'twilio-sms-inbound-gambit-relay');
+  const gambitWorker = gambitWorkerApp.worker;
+
+  // Gambit order retry suppression
+  const retrySuppressResponse = new Response(
+    'Unknown Gambit error',
+    {
+      status: 422,
+      statusText: 'Unknown Gambit error',
+      headers: {
+        // Also make sure that blink recongnizes non standart header case
+        'X-BlInK-RetRY-SuPPRESS': 'TRUE',
+      },
+    },
+  );
+
+  gambitWorker.checkRetrySuppress(retrySuppressResponse).should.be.true;
+
+
+  // Normal Gambit 422 response
+  const normalFailedResponse = new Response(
+    'Unknown Gambit error',
+    {
+      status: 422,
+      statusText: 'Unknown Gambit error',
+      headers: {
+        'x-taco-count': 'infinity',
+      },
+    },
+  );
+  gambitWorker.checkRetrySuppress(normalFailedResponse).should.be.false;
+});
+
+test('Gambit should process delivered messages', () => {
+  const messageData = MessageFactoryHelper.getValidMessageData();
+  messageData.payload.data.MessageStatus = 'delivered';
+  TwilioSmsInboundGambitRelayWorker.shouldSkip(messageData).should.be.false;
+});
+
+test('Gambit should not process not inbound messages', () => {
+  const messageData = MessageFactoryHelper.getValidMessageData();
+  messageData.payload.data.MessageStatus = 'other';
+  TwilioSmsInboundGambitRelayWorker.shouldSkip(messageData).should.be.true;
+});
+
+// ------- End -----------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
- Creates Gambit inbound sms relay worker that passes all Twilio Inbound Request URI messages Gambit Conversations `/recieve-message`. No data validation is imposed to this messages, except being a valid JSON.

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn web`
- `yarn worker twilio-sms-inbound-gambit-relay`
- Send curl request:

```
curl -X POST \
  'http://localhost:5050/api/v1/webhooks/twilio-sms-inbound' \
  -H 'authorization: Basic Ymxpbms6Ymxpbms=' \
  -H 'content-type: application/json' \
  -d '{}'
```
Where data should be a valid payload sent from Twilio.

#### What are the relevant tickets?
Pivotal [151620532](https://www.pivotaltracker.com/story/show/151620532)
Closes #119