### PR TITLE
[#151022906] Send generic JSON payloads from web endpoint to a queue owned by Data team

### DIFF
--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -70,6 +70,11 @@ class BlinkWebApp extends BlinkApp {
       '/api/v1/events/user-signup-post',
       eventsWebController.userSignupPost,
     );
+    router.post(
+      'api.v1.events.quasar-relay',
+      '/api/v1/events/quasar-relay',
+      eventsWebController.quasarRelay,
+    );
 
     // Webhooks
     router.get('api.v1.webhooks', '/api/v1/webhooks', webHooksWebController.index);

--- a/src/queues/QuasarCustomerIoEmailActivityQ.js
+++ b/src/queues/QuasarCustomerIoEmailActivityQ.js
@@ -3,7 +3,10 @@
 const Queue = require('./Queue');
 
 class QuasarCustomerIoEmailActivityQ extends Queue {
-
+  constructor(...args) {
+    super(...args);
+    this.routes.push('generic-event.quasar');
+  }
 }
 
 module.exports = QuasarCustomerIoEmailActivityQ;

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -2,6 +2,7 @@
 
 const CampaignSignupMessage = require('../../messages/CampaignSignupMessage');
 const CampaignSignupPostMessage = require('../../messages/CampaignSignupPostMessage');
+const FreeFormMessage = require('../../messages/FreeFormMessage');
 const UserMessage = require('../../messages/UserMessage');
 const WebController = require('./WebController');
 
@@ -13,6 +14,7 @@ class EventsWebController extends WebController {
     this.userCreate = this.userCreate.bind(this);
     this.userSignup = this.userSignup.bind(this);
     this.userSignupPost = this.userSignupPost.bind(this);
+    this.quasarRelay = this.quasarRelay.bind(this);
   }
 
   async index(ctx) {
@@ -20,6 +22,7 @@ class EventsWebController extends WebController {
       'user-create': this.fullUrl('api.v1.events.user-create'),
       'user-signup': this.fullUrl('api.v1.events.user-signup'),
       'user-signup-post': this.fullUrl('api.v1.events.user-signup-post'),
+      'quasar-relay': this.fullUrl('api.v1.events.quasar-relay'),
     };
   }
 
@@ -57,6 +60,20 @@ class EventsWebController extends WebController {
       message.validateStrict();
       this.blink.exchange.publish(
         'signup-post.user.event',
+        message,
+      );
+      this.sendOK(ctx, message);
+    } catch (error) {
+      this.sendError(ctx, error);
+    }
+  }
+
+  async quasarRelay(ctx) {
+    try {
+      const message = FreeFormMessage.fromCtx(ctx);
+      message.validate();
+      this.blink.exchange.publish(
+        'generic-event.quasar',
         message,
       );
       this.sendOK(ctx, message);

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -4,5 +4,9 @@ module.exports = {
     // Allow skipping for now.
     // TODO: remove this override when the refactoring is complete.
     'ava/no-skip-test': 'off',
+    // Allow all common iterator names as well as `t` for tests
+    'id-length': ['error', { exceptions: ['t', 'i', 'j', 'k'] }],
+    // Allow i++ in fors
+    'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
   },
 };

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -266,7 +266,6 @@ class MessageFactoryHelper {
 
     return data;
   }
-
 }
 
 module.exports = MessageFactoryHelper;

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -244,6 +244,29 @@ class MessageFactoryHelper {
       meta: {},
     });
   }
+
+  static getRandomDataSample(nested = false) {
+    const data = {};
+
+    // Add random words.
+    for (let i = 0; i < 8; i++) {
+      data[chance.word()] = chance.word();
+    }
+
+    // One int.
+    data[chance.word()] = chance.integer();
+
+    // One bool
+    data[chance.word()] = chance.bool();
+
+    // Add nested object.
+    if (nested) {
+      data[chance.word()] = MessageFactoryHelper.getRandomDataSample();
+    }
+
+    return data;
+  }
+
 }
 
 module.exports = MessageFactoryHelper;

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -242,7 +242,7 @@ test('POST /api/v1/events/user-signup-post should publish message to user-signup
 /**
  * POST /api/v1/events/quasar-relay
  */
-test('POST /api/v1/events/quasar-relay should save message as is to quasar queue', async (t) => {
+test.serial('POST /api/v1/events/quasar-relay should save message as is to quasar queue', async (t) => {
   const data = MessageFactoryHelper.getRandomDataSample();
 
   const res = await t.context.supertest.post('/api/v1/events/quasar-relay')

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -261,7 +261,8 @@ test('POST /api/v1/events/quasar-relay should save message as is to quasar queue
   // Check that the message is queued.
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);
 
-  // TODO: quasar-customer-io-email-activity to be renamed to quasar
+  // TODO: quasar-customer-io-email-activity to be renamed.
+  // See https://github.com/DoSomething/blink/issues/99
   // See https://www.pivotaltracker.com/story/show/150330459
   const messages = await rabbit.getMessagesFrom('quasar-customer-io-email-activity', 1, false);
   messages.should.be.an('array').and.to.have.lengthOf(1);

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -31,12 +31,22 @@ test('GET /api/v1/events should respond with JSON list available tools', async (
     .and.have.string('application/json');
 
   // Check response.
+  // TODO: map key to destination and check them in loop.
+
   res.body.should.have.property('user-create')
     .and.have.string('/api/v1/events/user-create');
+
   res.body.should.have.property('user-signup')
     .and.have.string('/api/v1/events/user-signup');
+
+  res.body.should.have.property('user-signup')
+    .and.have.string('/api/v1/events/user-signup');
+
   res.body.should.have.property('user-signup-post')
     .and.have.string('/api/v1/events/user-signup-post');
+
+  res.body.should.have.property('quasar-relay')
+    .and.have.string('/api/v1/events/quasar-relay');
 });
 
 
@@ -227,5 +237,43 @@ test('POST /api/v1/events/user-signup-post should publish message to user-signup
     }
   });
 });
+
+
+/**
+ * POST /api/v1/events/user-signup-post
+ */
+test('POST /api/v1/events/quasar-relay should save message as is to quasar queue', async (t) => {
+  const data = MessageFactoryHelper.getRandomDataSample();
+
+  const res = await t.context.supertest.post('/api/v1/events/quasar-relay')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(202);
+
+  // Check response to be json
+  res.header.should.have.property('content-type');
+  res.header['content-type'].should.match(/json/);
+
+  // Check response.
+  res.body.should.have.property('ok', true);
+
+  // Check that the message is queued.
+  const rabbit = new RabbitManagement(t.context.config.amqpManagement);
+
+  // TODO: quasar-customer-io-email-activity to be renamed to quasar
+  // See https://www.pivotaltracker.com/story/show/150330459
+  const messages = await rabbit.getMessagesFrom('quasar-customer-io-email-activity', 1, false);
+  messages.should.be.an('array').and.to.have.lengthOf(1);
+
+  messages[0].should.have.property('payload');
+  const payload = messages[0].payload;
+  const messageData = JSON.parse(payload);
+  messageData.should.have.property('data');
+
+  // Required.
+  messageData.data.should.deep.equal(data);
+});
+
 
 // ------- End -----------------------------------------------------------------

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -240,7 +240,7 @@ test('POST /api/v1/events/user-signup-post should publish message to user-signup
 
 
 /**
- * POST /api/v1/events/user-signup-post
+ * POST /api/v1/events/quasar-relay
  */
 test('POST /api/v1/events/quasar-relay should save message as is to quasar queue', async (t) => {
   const data = MessageFactoryHelper.getRandomDataSample();

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -53,7 +53,7 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
 /**
  * POST /api/v1/webhooks/customerio
  */
-test('POST /api/v1/webhooks/customerio-email-activity should publish message to customer-io queue', async (t) => {
+test.serial('POST /api/v1/webhooks/customerio-email-activity should publish message to customer-io queue', async (t) => {
   const data = {
     data: {
       campaign_id: '0',

--- a/test/web/controllers/WebHooksWebController.test.js
+++ b/test/web/controllers/WebHooksWebController.test.js
@@ -83,8 +83,8 @@ test('POST /api/v1/webhooks/customerio-email-activity should publish message to 
 
   // Check that the message is queued.
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);
-  // TODO: queue cleanup to make sure that it's not OLD message.
-  const messages = await rabbit.getMessagesFrom('quasar-customer-io-email-activity', 1);
+  // Note: might be in conflict with POST /api/v1/events/quasar-relay test
+  const messages = await rabbit.getMessagesFrom('quasar-customer-io-email-activity', 1, false);
   messages.should.be.an('array').and.to.have.lengthOf(1);
 
   messages[0].should.have.property('payload');


### PR DESCRIPTION
#### What's this PR do?
- Implements web endpoint `/api/v1/events/quasar-relay`
- Saves all JSON payloads received by the endpoint to `quasar-customer-io-email-activity` queue (a subject to change changed as described in #99)

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
- `yarn web`
- Send freeform JSON to `/api/v1/events/quasar-relay`
- Make sure you can see the payload in http://localhost:15672/#/queues/blink/customer-io-update-customer -> Get Messages

#### Any background context you want to provide?
For now, `quasar-customer-io-email-activity` queue is used for a generic integration with Data consumer. It will be renamed to `data-prime` queue or `quasar-data-prime` soon, see #99.

#### What are the relevant tickets?
Pivotal [#151022906](https://www.pivotaltracker.com/story/show/151022906)
A part of #127