### PR TITLE
[#151266508] Send Rogue campaign signup events to Gambit Conversations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,6 +4,7 @@ gambit-chatbot-mdata-proxy: npm run worker gambit-chatbot-mdata-proxy
 customer-io-update-customer: npm run worker customer-io-update-customer
 customer-io-campaign-signup: npm run worker customer-io-campaign-signup
 customer-io-campaign-signup-post: npm run worker customer-io-campaign-signup-post
+gambit-campaign-signup-relay: npm run worker gambit-campaign-signup-relay
 gambit-message-data-relay: npm run worker gambit-message-data-relay
 twilio-sms-broadcast-gambit-relay: npm run worker twilio-sms-broadcast-gambit-relay
 twilio-sms-inbound-gambit-relay: npm run worker twilio-sms-inbound-gambit-relay

--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -9,6 +9,7 @@ const CustomerIoCampaignSignupPostQ = require('../queues/CustomerIoCampaignSignu
 const CustomerIoCampaignSignupQ = require('../queues/CustomerIoCampaignSignupQ');
 const CustomerIoUpdateCustomerQ = require('../queues/CustomerIoUpdateCustomerQ');
 const FetchQ = require('../queues/FetchQ');
+const GambitCampaignSignupRelayQ = require('../queues/GambitCampaignSignupRelayQ');
 const GambitChatbotMdataQ = require('../queues/GambitChatbotMdataQ');
 const MocoMessageDataQ = require('../queues/MocoMessageDataQ');
 const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
@@ -51,6 +52,7 @@ class BlinkApp {
         CustomerIoCampaignSignupQ,
         CustomerIoUpdateCustomerQ,
         FetchQ,
+        GambitCampaignSignupRelayQ,
         GambitChatbotMdataQ,
         MocoMessageDataQ,
         QuasarCustomerIoEmailActivityQ,

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -5,6 +5,7 @@ const CustomerIoCampaignSignupPostWorker = require('../workers/CustomerIoCampaig
 const CustomerIoCampaignSignupWorker = require('../workers/CustomerIoCampaignSignupWorker');
 const CustomerIoUpdateCustomerWorker = require('../workers/CustomerIoUpdateCustomerWorker');
 const FetchWorker = require('../workers/FetchWorker');
+const GambitCampaignSignupRelayWorker = require('../workers/GambitCampaignSignupRelayWorker');
 const GambitChatbotMdataProxyWorker = require('../workers/GambitChatbotMdataProxyWorker');
 const GambitMessageDataRelayWorker = require('../workers/GambitMessageDataRelayWorker');
 const TwilioSmsBroadcastGambitRelayWorker = require('../workers/TwilioSmsBroadcastGambitRelayWorker');
@@ -35,9 +36,10 @@ class BlinkWorkerApp extends BlinkApp {
   static getAvailableWorkers() {
     return {
       fetch: FetchWorker,
-      'customer-io-update-customer': CustomerIoUpdateCustomerWorker,
       'customer-io-campaign-signup': CustomerIoCampaignSignupWorker,
       'customer-io-campaign-signup-post': CustomerIoCampaignSignupPostWorker,
+      'customer-io-update-customer': CustomerIoUpdateCustomerWorker,
+      'gambit-campaign-signup-relay': GambitCampaignSignupRelayWorker,
       'gambit-chatbot-mdata-proxy': GambitChatbotMdataProxyWorker,
       'gambit-message-data-relay': GambitMessageDataRelayWorker,
       'twilio-sms-broadcast-gambit-relay': TwilioSmsBroadcastGambitRelayWorker,

--- a/src/queues/GambitCampaignSignupRelayQ.js
+++ b/src/queues/GambitCampaignSignupRelayQ.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const CampaignSignupMessage = require('../messages/CampaignSignupMessage');
+const Queue = require('./Queue');
+
+class GambitCampaignSignupRelayQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.messageClass = CampaignSignupMessage;
+    this.routes.push('signup.user.event');
+  }
+}
+
+module.exports = GambitCampaignSignupRelayQ;

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -31,7 +31,7 @@ class GambitCampaignSignupRelayWorker extends Worker {
       campaignId: data.campaign_id,
       // Web signups are consdered external for Gambit.
       template: 'externalSignupMenuMessage',
-    }
+    };
 
     const headers = this.getRequestHeaders(message);
 

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -29,8 +29,8 @@ class GambitCampaignSignupRelayWorker extends Worker {
     const body = {
       northstarId: data.northstar_id,
       campaignId: data.campaign_id,
-      // Web signups are consdered external for Gambit.
-      template: 'externalSignupMenuMessage',
+      // Rogue signups are consdered external for Gambit.
+      template: 'externalSignupMenu',
     };
 
     const headers = this.getRequestHeaders(message);

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const fetch = require('node-fetch');
+const logger = require('winston');
+
+const BlinkRetryError = require('../errors/BlinkRetryError');
+const Worker = require('./Worker');
+
+class GambitCampaignSignupRelayWorker extends Worker {
+  constructor(blink) {
+    super(blink);
+    this.blink = blink;
+
+    this.baseURL = this.blink.config.gambit.converationsBaseUrl;
+    this.apiKey = this.blink.config.gambit.converationsApiKey;
+
+    // Bind process method to queue context
+    this.consume = this.consume.bind(this);
+  }
+
+  setup() {
+    this.queue = this.blink.queues.gambitCampaignSignupRelayQ;
+  }
+
+  async consume(message) {
+    const data = message.getData();
+
+    // See https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/send-message.md
+    const body = {
+      northstarId: data.northstar_id,
+      campaignId: data.campaign_id,
+      // Web signups are consdered external for Gambit.
+      template: 'externalSignupMenuMessage',
+    }
+
+    const headers = this.getRequestHeaders(message);
+
+    const response = await fetch(
+      `${this.baseURL}/send-message`,
+      {
+        method: 'POST',
+        headers,
+        body,
+      },
+    );
+
+    if (response.status === 200) {
+      this.log(
+        'debug',
+        message,
+        response,
+        'success_gambit_campaign_signup_relay_response_200',
+      );
+      return true;
+    }
+
+    if (this.checkRetrySuppress(response)) {
+      this.log(
+        'debug',
+        message,
+        response,
+        'success_gambit_campaign_signup_relay_retry_suppress',
+      );
+      return true;
+    }
+
+    if (response.status === 422) {
+      this.log(
+        'warning',
+        message,
+        response,
+        'error_gambit_campaign_signup_relay_response_422',
+      );
+      return false;
+    }
+
+
+    this.log(
+      'warning',
+      message,
+      response,
+      'error_gambit_campaign_signup_relay_response_not_200_retry',
+    );
+
+    throw new BlinkRetryError(
+      `${response.status} ${response.statusText}`,
+      message,
+    );
+  }
+
+  async log(level, message, response, code = 'unexpected_code') {
+    const cleanedBody = (await response.text()).replace(/\n/g, '\\n');
+
+    const meta = {
+      env: this.blink.config.app.env,
+      code,
+      worker: this.constructor.name,
+      request_id: message ? message.getRequestId() : 'not_parsed',
+      response_status: response.status,
+      response_status_text: `"${response.statusText}"`,
+    };
+    // Todo: log error?
+    logger.log(level, cleanedBody, meta);
+  }
+
+  getRequestHeaders(message) {
+    const headers = {
+      Authorization: `Basic ${this.apiKey}`,
+      'X-Request-ID': message.getRequestId(),
+      'Content-type': 'application/json',
+    };
+
+    if (message.getMeta().retry && message.getMeta().retry > 0) {
+      headers['x-blink-retry-count'] = message.getMeta().retry;
+    }
+
+    return headers;
+  }
+
+  checkRetrySuppress(response) {
+    // TODO: create common helper
+    const headerResult = response.headers.get(this.blink.config.app.retrySuppressHeader);
+    if (!headerResult) {
+      return false;
+    }
+    return headerResult.toLowerCase() === 'true';
+  }
+}
+
+module.exports = GambitCampaignSignupRelayWorker;

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -26,12 +26,13 @@ class GambitCampaignSignupRelayWorker extends Worker {
     const data = message.getData();
 
     // See https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/send-message.md
-    const body = {
+    const fields = {
       northstarId: data.northstar_id,
       campaignId: data.campaign_id,
       // Rogue signups are consdered external for Gambit.
       template: 'externalSignupMenu',
     };
+    const body = JSON.stringify(fields);
 
     const headers = this.getRequestHeaders(message);
 

--- a/test/web/controllers/EventsWebController.test.js
+++ b/test/web/controllers/EventsWebController.test.js
@@ -158,16 +158,15 @@ test('POST /api/v1/events/user-signup should publish message to user-signup-even
   // Check response.
   res.body.should.have.property('ok', true);
 
-  // Check that the message is queued.
+  // Check that the message is queued to customer-io-campaign-signup.
   const rabbit = new RabbitManagement(t.context.config.amqpManagement);
-  const messages = await rabbit.getMessagesFrom('customer-io-campaign-signup', 1, false);
-  messages.should.be.an('array').and.to.have.lengthOf(1);
+  const cioMessage = await rabbit.getMessagesFrom('customer-io-campaign-signup', 1, false);
+  cioMessage.should.be.an('array').and.to.have.lengthOf(1);
 
-  messages[0].should.have.property('payload');
-  const payload = messages[0].payload;
-  const messageData = JSON.parse(payload);
-  messageData.should.have.property('data');
-  messageData.data.should.be.eql({
+  cioMessage[0].should.have.property('payload');
+  const cioMessageData = JSON.parse(cioMessage[0].payload);
+  cioMessageData.should.have.property('data');
+  cioMessageData.data.should.be.eql({
     campaign_id: data.campaign_id,
     campaign_run_id: data.campaign_run_id,
     created_at: data.created_at,
@@ -175,36 +174,14 @@ test('POST /api/v1/events/user-signup should publish message to user-signup-even
     northstar_id: data.northstar_id,
     source: data.source,
   });
-});
 
-/**
- * POST /api/v1/events/user-signup
- */
-test('POST /api/v1/events/user-signup should publish message to gambit-campaign-signup-relay', async (t) => {
-  const data = MessageFactoryHelper.getValidCampaignSignup().getData();
-  const res = await t.context.supertest.post('/api/v1/events/user-signup')
-    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
-    .send(data);
+  const gambitMessage = await rabbit.getMessagesFrom('gambit-campaign-signup-relay', 1, false);
+  gambitMessage.should.be.an('array').and.to.have.lengthOf(1);
 
-  res.status.should.be.equal(202);
-
-  // Check response to be json
-  res.header.should.have.property('content-type');
-  res.header['content-type'].should.match(/json/);
-
-  // Check response.
-  res.body.should.have.property('ok', true);
-
-  // Check that the message is queued.
-  const rabbit = new RabbitManagement(t.context.config.amqpManagement);
-  const messages = await rabbit.getMessagesFrom('gambit-campaign-signup-relay', 1, false);
-  messages.should.be.an('array').and.to.have.lengthOf(1);
-
-  messages[0].should.have.property('payload');
-  const payload = messages[0].payload;
-  const messageData = JSON.parse(payload);
-  messageData.should.have.property('data');
-  messageData.data.should.be.eql({
+  gambitMessage[0].should.have.property('payload');
+  const gambitMessageData = JSON.parse(gambitMessage[0].payload);
+  gambitMessageData.should.have.property('data');
+  gambitMessageData.data.should.be.eql({
     campaign_id: data.campaign_id,
     campaign_run_id: data.campaign_run_id,
     created_at: data.created_at,

--- a/test/workers/GambitCampaignSignupRelayWorker.test.js
+++ b/test/workers/GambitCampaignSignupRelayWorker.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const chai = require('chai');
+const fetch = require('node-fetch');
+const test = require('ava');
+
+const BlinkWorkerApp = require('../../src/app/BlinkWorkerApp');
+const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+const { Response } = fetch;
+
+// ------- Tests ---------------------------------------------------------------
+
+test('Gambit should recieve correct retry count if message has been retried', () => {
+  const config = require('../../config');
+  const gambitWorkerApp = new BlinkWorkerApp(config, 'gambit-campaign-signup-relay');
+  const gambitWorker = gambitWorkerApp.worker;
+
+  // No retry property:
+  gambitWorker.getRequestHeaders(MessageFactoryHelper.getValidMdata())
+    .should.not.have.property('x-blink-retry-count');
+
+  // retry = 0
+  const retriedZero = MessageFactoryHelper.getValidMdata();
+  retriedZero.payload.meta.retry = 0;
+  gambitWorker.getRequestHeaders(retriedZero)
+    .should.not.have.property('x-blink-retry-count');
+
+  // retry = 1
+  const retriedOnce = MessageFactoryHelper.getValidMdata();
+  retriedOnce.payload.meta.retry = 1;
+  gambitWorker.getRequestHeaders(retriedOnce)
+    .should.have.property('x-blink-retry-count').and.equal(1);
+});
+
+
+test('Test Gambit response with x-blink-retry-suppress header', () => {
+  const config = require('../../config');
+  const gambitWorkerApp = new BlinkWorkerApp(config, 'gambit-campaign-signup-relay');
+  const gambitWorker = gambitWorkerApp.worker;
+
+  // Gambit order retry suppression
+  const retrySuppressResponse = new Response(
+    'Unknown Gambit error',
+    {
+      status: 422,
+      statusText: 'Unknown Gambit error',
+      headers: {
+        // Also make sure that blink recongnizes non standart header case
+        'X-BlInK-RetRY-SuPPRESS': 'TRUE',
+      },
+    },
+  );
+
+  gambitWorker.checkRetrySuppress(retrySuppressResponse).should.be.true;
+
+
+  // Normal Gambit 422 response
+  const normalFailedResponse = new Response(
+    'Unknown Gambit error',
+    {
+      status: 422,
+      statusText: 'Unknown Gambit error',
+      headers: {
+        'x-taco-count': 'infinity',
+      },
+    },
+  );
+  gambitWorker.checkRetrySuppress(normalFailedResponse).should.be.false;
+});
+
+// ------- End -----------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
- Creates `gambit-campaign-signup-relay` queue which recieves campiang signup messages
- Creates `gambit-campaign-signup-relay` worker which listenes for new messages in `gambit-campaign-signup-relay` queue and relayes them to Gambit Conversation in [specified](https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/send-message.md) format

#### How should this be manually tested?
- Sign up for a Thor campaign which is enabled in Gambit Campaigns Staging

#### What are the relevant tickets?
Pivotal [151266508](https://www.pivotaltracker.com/story/show/151266508)
Ref https://github.com/DoSomething/gambit-conversations/pull/155