### PR TITLE
Improve logging of invalid messages

### DIFF
--- a/src/web/controllers/WebController.js
+++ b/src/web/controllers/WebController.js
@@ -53,6 +53,9 @@ class WebController {
       ok: false,
     };
 
+    // Log message only when it's valid.
+    let message = false;
+
     // Check error type.
     let level;
     if (error instanceof MessageValidationBlinkError) {
@@ -60,6 +63,10 @@ class WebController {
       ctx.body.code = 'error_validation_failed';
       ctx.status = 422;
       level = 'warning';
+      // When message exists, log it.
+      if (error.payload) {
+        message = error.payload;
+      }
     } else {
       ctx.body.code = 'error_unexpected_controller_error';
       ctx.status = 400;
@@ -67,7 +74,7 @@ class WebController {
     }
     ctx.body.message = error.toString();
 
-    this.log(level, ctx, false, ctx.body.code);
+    this.log(level, ctx, message, ctx.body.code);
   }
 
   log(level, ctx, message, code) {


### PR DESCRIPTION
#### What's this PR do?
- Improves logging of invalid and unparsed messages

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`
- `yarn web`
- Request
```
curl -X POST \
  http://localhost:5050/api/v1/events/user-create \
  -H 'authorization: Basic Ymxpbms6Ymxpbms=' \
  -H 'content-type: application/json' \
  -d 1
```
Should show error:
```
2017-10-16T19:19:42.132Z app[]: at=warning application=blink env=development code=error_parsing_body request_id=a4ef7dd9-f59d-4a75-b63f-b1e31aa1180d method=POST host=localhost path=/api/v1/events/user-create fwd=::1 protocol=http Body parsing error.
```

- Request
```
curl -X POST \
  http://localhost:5050/api/v1/events/user-create \
  -H 'authorization: Basic Ymxpbms6Ymxpbms=' \
  -H 'content-type: application/json' \
  -d '{
	"id": "just-no"
}'
```
Should show error:
```
2017-10-16T19:20:10.287Z app[]: at=warning application=blink env=development code=error_validation_failed request_id=63625825-14b0-4495-ab33-8bbcbd08b3d4 method=POST host=localhost path=/api/v1/events/user-create fwd=::1 protocol=http MessageValidationBlinkError: child "id" fails because ["id" with value "just-no" fails to match the valid object id pattern], message {"data":{"id":"just-no"},"meta":{"request_id":"63625825-14b0-4495-ab33-8bbcbd08b3d4"}}
```

#### Any background context you want to provide?
Not logging these messages makes it impossible to figure out what's wrong with them.

#### What are the relevant tickets?
Fixes #149