### PR TITLE
[Finishes #152052652] Don't send Rogue signups to Gambit when they are created by Gambit

### DIFF
--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -33,7 +33,7 @@ class GambitCampaignSignupRelayWorker extends Worker {
         worker: this.constructor.name,
         request_id: message ? message.getRequestId() : 'not_parsed',
       };
-      logger.log('debug', body, meta);
+      logger.log('debug', JSON.stringify(data), meta);
       return true;
     }
 

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -140,7 +140,11 @@ class GambitCampaignSignupRelayWorker extends Worker {
   }
 
   static shouldSkip(message) {
-    return true;
+    const source = message.getData().source;
+    if (!source) {
+      return false;
+    }
+    return source.match(/^ *sms/) !== null;
   }
 }
 

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -25,6 +25,18 @@ class GambitCampaignSignupRelayWorker extends Worker {
   async consume(message) {
     const data = message.getData();
 
+    // Send only delivered messages to Gambit Conversations import.
+    if (GambitCampaignSignupRelayWorker.shouldSkip(message)) {
+      const meta = {
+        env: this.blink.config.app.env,
+        code: 'success_gambit_campaign_signup_relay_expected_skip',
+        worker: this.constructor.name,
+        request_id: message ? message.getRequestId() : 'not_parsed',
+      };
+      logger.log('debug', body, meta);
+      return true;
+    }
+
     // See https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/send-message.md
     const fields = {
       northstarId: data.northstar_id,
@@ -125,6 +137,10 @@ class GambitCampaignSignupRelayWorker extends Worker {
       return false;
     }
     return headerResult.toLowerCase() === 'true';
+  }
+
+  static shouldSkip(message) {
+    return true;
   }
 }
 

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -193,6 +193,7 @@ class MessageFactoryHelper {
         campaign_run_id: chance.string({ length: 4, pool: '1234567890' }),
         quantity: null,
         why_participated: null,
+        // Don't add sms signup here, they are tested separately.
         source: chance.pickone(['campaigns', 'phoenix-web']),
         created_at: createdAt,
         updated_at: updatedAt,

--- a/test/workers/GambitCampaignSignupRelayWorker.test.js
+++ b/test/workers/GambitCampaignSignupRelayWorker.test.js
@@ -2,17 +2,20 @@
 
 // ------- Imports -------------------------------------------------------------
 
-const chai = require('chai');
-const fetch = require('node-fetch');
 const test = require('ava');
+const chai = require('chai');
+const Chance = require('chance');
+const fetch = require('node-fetch');
 
 const BlinkWorkerApp = require('../../src/app/BlinkWorkerApp');
+const GambitCampaignSignupRelayWorker = require('../../src/workers/GambitCampaignSignupRelayWorker');
 const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
 
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
 const { Response } = fetch;
+const chance = new Chance();
 
 // ------- Tests ---------------------------------------------------------------
 
@@ -73,5 +76,31 @@ test('Test Gambit response with x-blink-retry-suppress header', () => {
   );
   gambitWorker.checkRetrySuppress(normalFailedResponse).should.be.false;
 });
+
+test('Gambit should recieve signups not created by Gambit', () => {
+  // Helper specifically will not return sms-related signup source.
+  const messageData = MessageFactoryHelper.getValidCampaignSignup();
+  GambitCampaignSignupRelayWorker.shouldSkip(messageData).should.be.false;
+});
+
+test('Gambit should not recieve signups created by Gambit', () => {
+  const messageData = MessageFactoryHelper.getValidCampaignSignup();
+  const smsRelatedSources = [
+    'sms',
+    `sms${chance.word()}`,
+    `sms-${chance.word()}`,
+    `sms${chance.natural()}`,
+    'sms ',
+    ' sms ',
+    ` sms${chance.word()}`,
+  ];
+
+  for (const source of smsRelatedSources) {
+    messageData.payload.data.source = source;
+    GambitCampaignSignupRelayWorker.shouldSkip(messageData).should.be.true;
+  }
+
+});
+
 
 // ------- End -----------------------------------------------------------------

--- a/test/workers/GambitCampaignSignupRelayWorker.test.js
+++ b/test/workers/GambitCampaignSignupRelayWorker.test.js
@@ -95,12 +95,10 @@ test('Gambit should not recieve signups created by Gambit', () => {
     ` sms${chance.word()}`,
   ];
 
-  for (const source of smsRelatedSources) {
+  smsRelatedSources.forEach((source) => {
     messageData.payload.data.source = source;
     GambitCampaignSignupRelayWorker.shouldSkip(messageData).should.be.true;
-  }
-
+  });
 });
-
 
 // ------- End -----------------------------------------------------------------

--- a/test/workers/GambitCampaignSignupRelayWorker.test.js
+++ b/test/workers/GambitCampaignSignupRelayWorker.test.js
@@ -79,12 +79,12 @@ test('Test Gambit response with x-blink-retry-suppress header', () => {
 
 test('Gambit should recieve signups not created by Gambit', () => {
   // Helper specifically will not return sms-related signup source.
-  const messageData = MessageFactoryHelper.getValidCampaignSignup();
-  GambitCampaignSignupRelayWorker.shouldSkip(messageData).should.be.false;
+  const message = MessageFactoryHelper.getValidCampaignSignup();
+  GambitCampaignSignupRelayWorker.shouldSkip(message).should.be.false;
 });
 
 test('Gambit should not recieve signups created by Gambit', () => {
-  const messageData = MessageFactoryHelper.getValidCampaignSignup();
+  const message = MessageFactoryHelper.getValidCampaignSignup();
   const smsRelatedSources = [
     'sms',
     `sms${chance.word()}`,
@@ -96,8 +96,8 @@ test('Gambit should not recieve signups created by Gambit', () => {
   ];
 
   smsRelatedSources.forEach((source) => {
-    messageData.payload.data.source = source;
-    GambitCampaignSignupRelayWorker.shouldSkip(messageData).should.be.true;
+    message.payload.data.source = source;
+    GambitCampaignSignupRelayWorker.shouldSkip(message).should.be.true;
   });
 });
 


### PR DESCRIPTION
#### What's this PR do?
- Performs source filtering on Rogue signups in `GambitCampaignSignupRelayWorker`

#### How should this be tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### How should this be tested on staging?
See steps to reproduce manually in #152.

#### What are the relevant tickets?
Pivotal [152052652](https://www.pivotaltracker.com/story/show/152052652)
Fixes #152 