### PR TITLE
[#152113738] Test coverage for RetryManager

### DIFF
--- a/src/lib/DelayLogic.js
+++ b/src/lib/DelayLogic.js
@@ -8,12 +8,12 @@ class DelayLogic {
    * Visualization:
    * @see  https://docs.google.com/spreadsheets/d/1AECd5YrOXJnYlH7BW9wtPBL2Tqp5Wjd3c0VnYGqA780/edit?usp=sharing
    *
-   * @param  {int} currentRetryNumber - Retry number
+   * @param  {int} currentRetryAttempt - Retry attempt counter
    * @return {int} Milliseconds to wait
    */
-  static exponentialBackoff(currentRetryNumber) {
+  static exponentialBackoff(currentRetryAttempt) {
     // eslint-disable-next-line no-mixed-operators
-    return ((currentRetryNumber ** 2) / 4 + 1) * 1000;
+    return ((currentRetryAttempt ** 2) / 4 + 1) * 1000;
   }
 }
 

--- a/src/lib/Dequeuer.js
+++ b/src/lib/Dequeuer.js
@@ -31,7 +31,7 @@ class Dequeuer {
     try {
       result = await this.callback(message);
     } catch (error) {
-      return this.processCallbackError(message, error);
+      return await this.processCallbackError(message, error);
     }
 
     return this.processCallbackResult(message, result);
@@ -58,10 +58,10 @@ class Dequeuer {
     return true;
   }
 
-  processCallbackError(message, error) {
+  async processCallbackError(message, error) {
     // Got retry request.
     if (error instanceof BlinkRetryError) {
-      return this.retryManager.retry(message, error);
+      return await this.retryManager.retry(message, error);
     }
 
     // Really unexpected error, no retry requested.

--- a/src/lib/Dequeuer.js
+++ b/src/lib/Dequeuer.js
@@ -31,7 +31,7 @@ class Dequeuer {
     try {
       result = await this.callback(message);
     } catch (error) {
-      return await this.processCallbackError(message, error);
+      return this.processCallbackError(message, error);
     }
 
     return this.processCallbackResult(message, result);
@@ -61,7 +61,7 @@ class Dequeuer {
   async processCallbackError(message, error) {
     // Got retry request.
     if (error instanceof BlinkRetryError) {
-      return await this.retryManager.retry(message, error);
+      return this.retryManager.retry(message, error);
     }
 
     // Really unexpected error, no retry requested.

--- a/src/lib/RetryManager.js
+++ b/src/lib/RetryManager.js
@@ -5,15 +5,15 @@ const logger = require('winston');
 const DelayLogic = require('./DelayLogic');
 
 class RetryManager {
-  constructor(queue, retryDelayLogic = false) {
+  constructor(queue, republishDelayLogic = false) {
     this.queue = queue;
 
     // Retry delay logic.
-    if (!retryDelayLogic || typeof retryDelayLogic !== 'function') {
+    if (!republishDelayLogic || typeof republishDelayLogic !== 'function') {
       // Default exponential backoff logic
       this.retryAttemptToDelayTime = DelayLogic.exponentialBackoff;
     } else {
-      this.retryAttemptToDelayTime = retryDelayLogic;
+      this.retryAttemptToDelayTime = republishDelayLogic;
     }
 
     // Retry limit is a hardcoded const now.

--- a/src/lib/RetryManager.js
+++ b/src/lib/RetryManager.js
@@ -11,9 +11,9 @@ class RetryManager {
     // Retry delay logic.
     if (!retryDelayLogic || typeof retryDelayLogic !== 'function') {
       // Default exponential backoff logic
-      this.retryNumberToDelayMs = DelayLogic.exponentialBackoff;
+      this.retryAttemptToDelayTime = DelayLogic.exponentialBackoff;
     } else {
-      this.retryNumberToDelayMs = retryDelayLogic;
+      this.retryAttemptToDelayTime = retryDelayLogic;
     }
 
     // Retry limit is a hardcoded const now.
@@ -36,7 +36,7 @@ class RetryManager {
     }
 
     // Calculate wait time until the redelivery.
-    const delayMs = this.retryNumberToDelayMs(retryAttempt);
+    const delayMs = this.retryAttemptToDelayTime(retryAttempt);
 
     // Log retry information.
     this.log(

--- a/src/lib/RetryManager.js
+++ b/src/lib/RetryManager.js
@@ -46,9 +46,7 @@ class RetryManager {
       'debug_retry_manager_redeliver_scheduled',
     );
 
-    // Delay the redelivery.
-    await this.republishWithDelay(message, delayMs, error.toString());
-    return true;
+    return this.republishWithDelay(message, delayMs, error.toString());
   }
 
   async republishWithDelay(message, delayMs, reason = 'unknown') {
@@ -73,6 +71,7 @@ class RetryManager {
     this.queue.nack(message);
     // Republish modified message.
     this.queue.publish(retryMessage);
+    return true;
   }
 
   log(level, logMessage, message = {}, code = 'unexpected_code') {

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -11,6 +11,10 @@ class Message {
     this.payload = { data, meta };
     // Generate unique message id or reuse request id.
     this.payload.meta.request_id = this.payload.meta.request_id || uuidV4();
+    // Automatically set retryAttempt to 0.
+    if (!this.payload.meta.retryAttempt || this.payload.meta.retryAttempt < 1) {
+      this.payload.meta.retryAttempt = 0;
+    }
 
     // Bind public functions.
     this.getData = this.getData.bind(this);
@@ -31,6 +35,18 @@ class Message {
 
   getRequestId() {
     return this.payload.meta.request_id;
+  }
+
+  getRetryAttempt() {
+    return this.payload.meta.retryAttempt || 0;
+  }
+
+  incrementRetryAttempt(reason) {
+    this.payload.meta.retryAttempt = this.getRetryAttempt() + 1;
+    if (reason) {
+      this.payload.meta.retryReason = reason;
+    }
+    return this.payload.meta.retryAttempt;
   }
 
   toString() {

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -123,8 +123,8 @@ class GambitCampaignSignupRelayWorker extends Worker {
       'Content-type': 'application/json',
     };
 
-    if (message.getMeta().retryAttempt && message.getMeta().retryAttempt > 0) {
-      headers['x-blink-retry-count'] = message.getMeta().retryAttempt;
+    if (message.getRetryAttempt() > 0) {
+      headers['x-blink-retry-count'] = message.getRetryAttempt();
     }
 
     return headers;

--- a/src/workers/GambitChatbotMdataProxyWorker.js
+++ b/src/workers/GambitChatbotMdataProxyWorker.js
@@ -115,8 +115,8 @@ class GambitChatbotMdataProxyWorker extends Worker {
       'Content-type': 'application/json',
     };
 
-    if (mdataMessage.getMeta().retryAttempt && mdataMessage.getMeta().retryAttempt > 0) {
-      headers['x-blink-retry-count'] = mdataMessage.getMeta().retryAttempt;
+    if (mdataMessage.getRetryAttempt() > 0) {
+      headers['x-blink-retry-count'] = mdataMessage.getRetryAttempt();
     }
 
     return headers;

--- a/src/workers/GambitMessageDataRelayWorker.js
+++ b/src/workers/GambitMessageDataRelayWorker.js
@@ -114,8 +114,8 @@ class GambitMessageDataRelayWorker extends Worker {
       'Content-type': 'application/json',
     };
 
-    if (message.getMeta().retryAttempt && message.getMeta().retryAttempt > 0) {
-      headers['x-blink-retry-count'] = message.getMeta().retryAttempt;
+    if (message.getRetryAttempt() > 0) {
+      headers['x-blink-retry-count'] = message.getRetryAttempt();
     }
 
     return headers;

--- a/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
+++ b/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
@@ -128,8 +128,8 @@ class TwilioSmsBroadcastGambitRelayWorker extends Worker {
       'Content-type': 'application/json',
     };
 
-    if (message.getMeta().retryAttempt && message.getMeta().retryAttempt > 0) {
-      headers['x-blink-retry-count'] = message.getMeta().retryAttempt;
+    if (message.getRetryAttempt() > 0) {
+      headers['x-blink-retry-count'] = message.getRetryAttempt();
     }
 
     return headers;

--- a/src/workers/TwilioSmsInboundGambitRelayWorker.js
+++ b/src/workers/TwilioSmsInboundGambitRelayWorker.js
@@ -100,8 +100,8 @@ class TwilioSmsInboundGambitRelayWorker extends Worker {
       'Content-type': 'application/json',
     };
 
-    if (message.getMeta().retryAttempt && message.getMeta().retryAttempt > 0) {
-      headers['x-blink-retry-count'] = message.getMeta().retryAttempt;
+    if (message.getRetryAttempt() > 0) {
+      headers['x-blink-retry-count'] = message.getRetryAttempt();
     }
 
     return headers;

--- a/test/helpers/HooksHelper.js
+++ b/test/helpers/HooksHelper.js
@@ -43,25 +43,31 @@ class HooksHelper {
   }
 
   static async createRandomQueue(t) {
+    await HooksHelper.createRandomQueueInMemory(t);
+    await t.context.queue.setup();
+  }
+
+  static async destroyRandomQueue(t) {
+    await t.context.queue.delete();
+    t.context.exchange.channel.close();
+    t.context.exchange.connection.close();
+    HooksHelper.destroyRandomQueueInMemory(t);
+  }
+
+  static async createRandomQueueInMemory(t) {
     const config = require('../../config');
     const exchange = new Exchange(config);
-
-    t.context.config = config;
+    // Todo: make independent.
     await exchange.setup();
 
     const queue = new Queue(exchange, `test-autogen-${chance.word()}-${chance.word()}`);
-    await queue.setup();
     queue.messageClass = FreeFormMessage;
 
     t.context.exchange = exchange;
     t.context.queue = queue;
   }
 
-  static async destroyRandomQueue(t) {
-    await t.context.queue.delete();
-
-    t.context.exchange.channel.close();
-    t.context.exchange.connection.close();
+  static destroyRandomQueueInMemory(t) {
     t.context.queue = false;
     t.context.exchange = false;
   }

--- a/test/lib/Dequeuer.test.js
+++ b/test/lib/Dequeuer.test.js
@@ -20,8 +20,8 @@ chai.should();
 chai.use(sinonChai);
 
 // Setup blink app for each test.
-test.beforeEach(HooksHelper.createRandomQueue);
-test.afterEach.always(HooksHelper.destroyRandomQueue);
+test.beforeEach(HooksHelper.createRandomQueueInMemory);
+test.afterEach.always(HooksHelper.destroyRandomQueueInMemory);
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/test/lib/Dequeuer.test.js
+++ b/test/lib/Dequeuer.test.js
@@ -153,7 +153,7 @@ test('Dequeuer.executeCallback(): ensure RetryManager is called when a retry is 
 
   // Create retry manager and spy on it.
   const retryManager = new RetryManager();
-  const retryStub = sinon.stub(retryManager, 'retry').returns(true);
+  const retryStub = sinon.stub(retryManager, 'retry').resolves(true);
 
   // Execute callback using dequeuer.
   const dequeuer = new Dequeuer(queue, callbackSpy, retryManager);

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -55,7 +55,7 @@ test('RetryManager.retry(): ensure nack when retry limit is reached', (t) => {
   const nackStub = sinon.stub(queue, 'nack').returns(null);
 
   // Create retryManager.
-  const retryManager = new RetryManager(t.context.queue);
+  const retryManager = new RetryManager(queue);
 
   // Prepare retry message for the manager.
   const message = MessageFactoryHelper.getRandomMessage();
@@ -74,6 +74,42 @@ test('RetryManager.retry(): ensure nack when retry limit is reached', (t) => {
   // Cleanup.
   ackStub.restore();
   nackStub.restore();
+});
+
+/**
+ * RetryManager.retry()
+ */
+test('RetryManager.retry(): should call scheduleRedeliveryIn with correct params', (t) => {
+  const queue = t.context.queue;
+
+  // Create retryManager.
+  const retryManager = new RetryManager(queue);
+
+  // Prepare retry message for the manager.
+  const message = MessageFactoryHelper.getRandomMessage();
+  const retryError = new BlinkRetryError('Testing BlinkRetryError', message);
+  // Set current retry attempt to the limit set in the manager - 1.
+  const retryAttempt = retryManager.retryLimit - 1;
+  message.payload.meta.retryAttempt = retryManager.retryLimit - 1;
+
+  // Stub scheduleRedeliveryIn.
+  const scheduleRedeliveryInStub = sinon.stub(retryManager, 'scheduleRedeliveryIn');
+  scheduleRedeliveryInStub.returns(null);
+
+  // Pass the message to retry().
+  const result = retryManager.retry(message, retryError);
+  result.should.be.true;
+
+  scheduleRedeliveryInStub.should.have.been.calledWith(
+    DelayLogic.exponentialBackoff(retryAttempt),
+    message,
+  );
+
+  // Ensure message has correct retryAttempt setting.
+  message.getMeta().retryAttempt.should.equal(retryAttempt);
+
+  // Cleanup.
+  scheduleRedeliveryInStub.restore();
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -60,7 +60,7 @@ test('RetryManager.retry(): ensure nack when retry limit is reached', async (t) 
   const message = MessageFactoryHelper.getRandomMessage();
   const retryError = new BlinkRetryError('Testing BlinkRetryError', message);
   // Set current retry attempt to the limit set in the manager + 1.
-  message.payload.meta.retryAttempt = retryManager.retryLimit + 1;
+  message.getMeta().retryAttempt = retryManager.retryLimit + 1;
 
   // Pass the message to retry().
   const result = await retryManager.retry(message, retryError);
@@ -90,7 +90,7 @@ test('RetryManager.retry(): should call republishWithDelay with correct params',
   // Set current retry attempt to the limit set in the manager - 1.
   // For example, if the limit is 100, we'll test retryAttempt = 99.
   const retryAttempt = retryManager.retryLimit - 1;
-  message.payload.meta.retryAttempt = retryAttempt;
+  message.getMeta().retryAttempt = retryAttempt;
 
   // Stub republishWithDelay.
   const republishWithDelayStub = sinon.stub(retryManager, 'republishWithDelay');

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+// const sinon = require('sinon');
+// const sinonChai = require('sinon-chai');
+
+// const BlinkRetryError = require('../../src/errors/BlinkRetryError');
+const RetryManager = require('../../src/lib/RetryManager');
+// const FreeFormMessage = require('../../src/messages/FreeFormMessage');
+// const HooksHelper = require('../helpers/HooksHelper');
+// const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+// chai.use(sinonChai);
+
+// Setup blink app for each test.
+// test.beforeEach(HooksHelper.createRandomQueue);
+// test.afterEach.always(HooksHelper.destroyRandomQueue);
+
+// ------- Tests ---------------------------------------------------------------
+
+/**
+ * RetryManager: constructor()
+ */
+test('RetryManager: Test class interface', (t) => {
+  const retryManager = new RetryManager(t.context.queue);
+  retryManager.should.respondTo('retry');
+  retryManager.should.respondTo('retryDelay');
+  retryManager.should.respondTo('scheduleRedeliveryIn');
+  retryManager.should.respondTo('redeliver');
+  retryManager.should.respondTo('log');
+  retryManager.should.have.property('retryLimit');
+});

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -9,6 +9,7 @@ const chai = require('chai');
 
 // const BlinkRetryError = require('../../src/errors/BlinkRetryError');
 const RetryManager = require('../../src/lib/RetryManager');
+const DelayLogic = require('../../src/lib/DelayLogic');
 // const FreeFormMessage = require('../../src/messages/FreeFormMessage');
 const HooksHelper = require('../helpers/HooksHelper');
 // const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
@@ -35,4 +36,12 @@ test('RetryManager: Test class interface', (t) => {
   retryManager.should.respondTo('redeliver');
   retryManager.should.respondTo('log');
   retryManager.should.have.property('retryLimit');
+  // Ensure default retry delay logic is DelayLogic.exponentialBackoff
+  retryManager.retryDelay.should.be.equal(DelayLogic.exponentialBackoff);
+
+  // Ensure it's possible to override DelayLogic
+  const customDelayLogic = currentRetryNumber => currentRetryNumber;
+  const retryManagerCustom = new RetryManager(t.context.queue, customDelayLogic);
+  retryManagerCustom.should.respondTo('retryDelay');
+  retryManagerCustom.retryDelay.should.be.equal(customDelayLogic);
 });

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -93,7 +93,7 @@ test('RetryManager.retry(): should call republishWithDelay with correct params',
 
   // Stub republishWithDelay.
   const republishWithDelayStub = sinon.stub(retryManager, 'republishWithDelay');
-  republishWithDelayStub.resolves(null);
+  republishWithDelayStub.resolves(true);
 
   // Pass the message to retry().
   const result = await retryManager.retry(message, retryError);

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -100,8 +100,8 @@ test('RetryManager.retry(): should call republishWithDelay with correct params',
   result.should.be.true;
 
   republishWithDelayStub.should.have.been.calledWith(
-    DelayLogic.exponentialBackoff(retryAttempt),
     message,
+    DelayLogic.exponentialBackoff(retryAttempt),
   );
 
   // Ensure message has correct retryAttempt setting.

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -30,18 +30,18 @@ test.afterEach.always(HooksHelper.destroyRandomQueueInMemory);
 test('RetryManager: Test class interface', (t) => {
   const retryManager = new RetryManager(t.context.queue);
   retryManager.should.respondTo('retry');
-  retryManager.should.respondTo('retryNumberToDelayMs');
+  retryManager.should.respondTo('retryAttemptToDelayTime');
   retryManager.should.respondTo('republishWithDelay');
   retryManager.should.respondTo('log');
   retryManager.should.have.property('retryLimit');
   // Ensure default retry delay logic is DelayLogic.exponentialBackoff
-  retryManager.retryNumberToDelayMs.should.be.equal(DelayLogic.exponentialBackoff);
+  retryManager.retryAttemptToDelayTime.should.be.equal(DelayLogic.exponentialBackoff);
 
   // Ensure it's possible to override DelayLogic
   const customDelayLogic = currentRetryNumber => currentRetryNumber;
   const retryManagerCustom = new RetryManager(t.context.queue, customDelayLogic);
-  retryManagerCustom.should.respondTo('retryNumberToDelayMs');
-  retryManagerCustom.retryNumberToDelayMs.should.be.equal(customDelayLogic);
+  retryManagerCustom.should.respondTo('retryAttemptToDelayTime');
+  retryManagerCustom.retryAttemptToDelayTime.should.be.equal(customDelayLogic);
 });
 
 /**

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -132,8 +132,23 @@ test('RetryManager.republishWithDelay(): should republish original message', asy
   message.incrementRetryAttempt(retryError.message);
 
 
-  // Pass the message to retry().
-  const result = await retryManager.republishWithDelay(message, 0);
+  // Fake clock so we don't have to wait on this implementation,
+  // but still are providing real wait time.
+  const waitTime = 60 * 1000; // 60s.
+  const clock = sinon.useFakeTimers();
+
+  // Request message republish in 60s.
+  const resultPromise = retryManager.republishWithDelay(message, waitTime);
+
+  // Advace the clock to wait time before actually waiting on promise.
+  clock.tick(waitTime);
+
+  // Should be resolved immidiatelly.
+  const result = await resultPromise;
+  // Important: reset the clock.
+  clock.restore();
+
+  // Unless error is thrown, result will be true.
   result.should.be.true;
 
   // Make sure message hasn been nackd and then republished again.

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -104,9 +104,6 @@ test('RetryManager.retry(): should call republishWithDelay with correct params',
     DelayLogic.exponentialBackoff(retryAttempt),
   );
 
-  // Ensure message has correct retryAttempt setting.
-  message.getMeta().retryAttempt.should.equal(retryAttempt);
-
   // Cleanup.
   republishWithDelayStub.restore();
 });

--- a/test/lib/RetryManager.test.js
+++ b/test/lib/RetryManager.test.js
@@ -10,7 +10,7 @@ const chai = require('chai');
 // const BlinkRetryError = require('../../src/errors/BlinkRetryError');
 const RetryManager = require('../../src/lib/RetryManager');
 // const FreeFormMessage = require('../../src/messages/FreeFormMessage');
-// const HooksHelper = require('../helpers/HooksHelper');
+const HooksHelper = require('../helpers/HooksHelper');
 // const MessageFactoryHelper = require('../helpers/MessageFactoryHelper');
 
 // ------- Init ----------------------------------------------------------------
@@ -19,8 +19,8 @@ chai.should();
 // chai.use(sinonChai);
 
 // Setup blink app for each test.
-// test.beforeEach(HooksHelper.createRandomQueue);
-// test.afterEach.always(HooksHelper.destroyRandomQueue);
+test.beforeEach(HooksHelper.createRandomQueueInMemory);
+test.afterEach.always(HooksHelper.destroyRandomQueueInMemory);
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/test/workers/GambitCampaignSignupRelayWorker.test.js
+++ b/test/workers/GambitCampaignSignupRelayWorker.test.js
@@ -30,13 +30,12 @@ test('Gambit should recieve correct retry count if message has been retried', ()
 
   // retry = 0
   const retriedZero = MessageFactoryHelper.getValidMdata();
-  retriedZero.payload.meta.retryAttempt = 0;
   gambitWorker.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
   const retriedOnce = MessageFactoryHelper.getValidMdata();
-  retriedOnce.payload.meta.retryAttempt = 1;
+  retriedOnce.incrementRetryAttempt();
   gambitWorker.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);
 });

--- a/test/workers/GambitChatbotMdataProxyWorker.test.js
+++ b/test/workers/GambitChatbotMdataProxyWorker.test.js
@@ -27,13 +27,12 @@ test('Gambit should recieve correct retry count if message has been retried', ()
 
   // retry = 0
   const retriedZero = MessageFactoryHelper.getValidMdata();
-  retriedZero.payload.meta.retryAttempt = 0;
   gambitWorker.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
   const retriedOnce = MessageFactoryHelper.getValidMdata();
-  retriedOnce.payload.meta.retryAttempt = 1;
+  retriedOnce.incrementRetryAttempt();
   gambitWorker.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);
 });

--- a/test/workers/GambitMessageDataRelayWorker.test.js
+++ b/test/workers/GambitMessageDataRelayWorker.test.js
@@ -28,13 +28,12 @@ test('Gambit should recieve correct retry count if message has been retried', ()
 
   // retry = 0
   const retriedZero = MessageFactoryHelper.getValidMessageData();
-  retriedZero.payload.meta.retryAttempt = 0;
   gambitWorker.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
   const retriedOnce = MessageFactoryHelper.getValidMessageData();
-  retriedOnce.payload.meta.retryAttempt = 1;
+  retriedOnce.incrementRetryAttempt();
   gambitWorker.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);
 });

--- a/test/workers/TwilioSmsBroadcastGambitRelayWorker.test.js
+++ b/test/workers/TwilioSmsBroadcastGambitRelayWorker.test.js
@@ -28,13 +28,12 @@ test('Gambit Broadcast relay should recieve correct retry count if message has b
 
   // retry = 0
   const retriedZero = MessageFactoryHelper.getValidMessageData();
-  retriedZero.payload.meta.retryAttempt = 0;
   gambitWorker.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
   const retriedOnce = MessageFactoryHelper.getValidMessageData();
-  retriedOnce.payload.meta.retryAttempt = 1;
+  retriedOnce.incrementRetryAttempt();
   gambitWorker.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);
 });

--- a/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
+++ b/test/workers/TwilioSmsInboundGambitRelayWorker.test.js
@@ -27,13 +27,12 @@ test('Gambit Broadcast relay should recieve correct retry count if message has b
 
   // retry = 0
   const retriedZero = MessageFactoryHelper.getValidMessageData();
-  retriedZero.payload.meta.retryAttempt = 0;
   gambitWorker.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
   const retriedOnce = MessageFactoryHelper.getValidMessageData();
-  retriedOnce.payload.meta.retryAttempt = 1;
+  retriedOnce.incrementRetryAttempt();
   gambitWorker.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);
 });


### PR DESCRIPTION
#### What's this PR do?
- Changes API of `RetryManager.retry()`, it's async now and resolves into actual retry results
- Adds helpers methods on Message class exposing `.meta.retryAttempt` field and its incrementation logic
- 100% unit test coverage for RetryManager
- Provides additional test helpers to use Queue classes in memory and not actually asserting queues in RabbitMQ, when useful

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn all-tests`

#### What are the relevant tickets?
Pivotal [152113738](https://www.pivotaltracker.com/story/show/152113738)