### PR TITLE
Chore: update node to 8.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-beta.3",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
-    "node": "8.9.1",
+    "node": "8.9.3",
     "npm": "5.5.1",
     "yarn": "1.3.2"
   },

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: node:8.9.1
+box: node:8.9.3
 services:
   - id: rabbitmq:3.6.9-management
     env:


### PR DESCRIPTION
Updates Node.js engine to 8.9.3.

This is a security release upgrade, read more https://nodejs.org/en/blog/vulnerability/december-2017-security-releases/
