### PR TITLE
Refactoring: simplify concrete message classes

### DIFF
--- a/src/messages/CampaignSignupMessage.js
+++ b/src/messages/CampaignSignupMessage.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 const moment = require('moment');
 
-const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 const CustomerIoEvent = require('../models/CustomerIoEvent');
 const Message = require('./Message');
 
@@ -23,34 +22,6 @@ class CampaignSignupMessage extends Message {
         source: Joi.string().empty(whenNullOrEmpty).default(undefined),
         created_at: Joi.string().required().empty(whenNullOrEmpty).isoDate(),
       });
-  }
-
-  static fromCtx(ctx) {
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const message = new CampaignSignupMessage({
-      data: ctx.request.body,
-      meta: {
-        request_id: ctx.id,
-      },
-    });
-    return message;
-  }
-
-  static fromRabbitMessage(rabbitMessage) {
-    const payload = this.parseIncomingPayload(rabbitMessage);
-    if (!payload.data || !payload.meta) {
-      throw new MessageParsingBlinkError('No data in message', payload);
-    }
-
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const message = new CampaignSignupMessage({
-      data: payload.data,
-      meta: payload.meta,
-    });
-    message.fields = rabbitMessage.fields;
-    return message;
   }
 
   toCustomerIoEvent() {

--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 const moment = require('moment');
 
-const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 const CustomerIoEvent = require('../models/CustomerIoEvent');
 const Message = require('./Message');
 
@@ -33,34 +32,6 @@ class CampaignSignupPostMessage extends Message {
         // Time stamp.
         created_at: Joi.string().required().empty(whenNullOrEmpty).isoDate(),
       });
-  }
-
-  static fromCtx(ctx) {
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const message = new CampaignSignupPostMessage({
-      data: ctx.request.body,
-      meta: {
-        request_id: ctx.id,
-      },
-    });
-    return message;
-  }
-
-  static fromRabbitMessage(rabbitMessage) {
-    const payload = this.parseIncomingPayload(rabbitMessage);
-    if (!payload.data || !payload.meta) {
-      throw new MessageParsingBlinkError('No data in message', payload);
-    }
-
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const message = new CampaignSignupPostMessage({
-      data: payload.data,
-      meta: payload.meta,
-    });
-    message.fields = rabbitMessage.fields;
-    return message;
   }
 
   toCustomerIoEvent() {

--- a/src/messages/CustomerIoUpdateCustomerMessage.js
+++ b/src/messages/CustomerIoUpdateCustomerMessage.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 
 const Message = require('./Message');
 
+// TODO: Move this to be a Model. See CustomerIoEvent as an example.
 class CustomerIoUpdateCustomerMessage extends Message {
   constructor(...args) {
     super(...args);

--- a/src/messages/CustomerIoWebhookMessage.js
+++ b/src/messages/CustomerIoWebhookMessage.js
@@ -18,18 +18,6 @@ class CustomerIoWebhookMessage extends Message {
       timestamp: Joi.number().integer().required(),
     });
   }
-
-  static fromCtx(ctx) {
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const fetchMessage = new CustomerIoWebhookMessage({
-      data: ctx.request.body,
-      meta: {
-        request_id: ctx.id,
-      },
-    });
-    return fetchMessage;
-  }
 }
 
 module.exports = CustomerIoWebhookMessage;

--- a/src/messages/CustomerioSmsBroadcastMessage.js
+++ b/src/messages/CustomerioSmsBroadcastMessage.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 
 const Message = require('./Message');
-const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 
 class CustomerioSmsBroadcastMessage extends Message {
   constructor(...args) {
@@ -38,35 +37,6 @@ class CustomerioSmsBroadcastMessage extends Message {
 
   setMessageSid(messageSid) {
     this.getMeta().messageSid = messageSid;
-  }
-
-  static fromCtx(ctx) {
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const meta = {
-      request_id: ctx.id,
-    };
-    const message = new CustomerioSmsBroadcastMessage({
-      data: ctx.request.body,
-      meta,
-    });
-    return message;
-  }
-
-  static fromRabbitMessage(rabbitMessage) {
-    const payload = this.parseIncomingPayload(rabbitMessage);
-    if (!payload.data || !payload.meta) {
-      throw new MessageParsingBlinkError('No data in message', payload);
-    }
-
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const message = new CustomerioSmsBroadcastMessage({
-      data: payload.data,
-      meta: payload.meta,
-    });
-    message.fields = rabbitMessage.fields;
-    return message;
   }
 }
 

--- a/src/messages/FetchMessage.js
+++ b/src/messages/FetchMessage.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 
 const Message = require('./Message');
-const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 
 // TODO: url whitelist
 // TODO: authentication
@@ -16,34 +15,6 @@ class FetchMessage extends Message {
       url: Joi.string().required(),
       options: Joi.object(),
     });
-  }
-
-  static fromCtx(ctx) {
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const fetchMessage = new FetchMessage({
-      data: ctx.request.body,
-      meta: {
-        request_id: ctx.id,
-      },
-    });
-    return fetchMessage;
-  }
-
-  static fromRabbitMessage(rabbitMessage) {
-    const payload = this.parseIncomingPayload(rabbitMessage);
-    if (!payload.data || !payload.meta) {
-      throw new MessageParsingBlinkError('No data in message', payload);
-    }
-
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const fetchMessage = new FetchMessage({
-      data: payload.data,
-      meta: payload.meta,
-    });
-    fetchMessage.fields = rabbitMessage.fields;
-    return fetchMessage;
   }
 }
 

--- a/src/messages/FreeFormMessage.js
+++ b/src/messages/FreeFormMessage.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 
 const Message = require('./Message');
-const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 
 class FreeFormMessage extends Message {
   constructor(...args) {
@@ -12,34 +11,6 @@ class FreeFormMessage extends Message {
     this.schema = Joi.object()
       // Allow presence of all other keys.
       .unknown();
-  }
-
-  static fromCtx(ctx) {
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const freeFormMessage = new FreeFormMessage({
-      data: ctx.request.body,
-      meta: {
-        request_id: ctx.id,
-      },
-    });
-    return freeFormMessage;
-  }
-
-  static fromRabbitMessage(rabbitMessage) {
-    const payload = this.parseIncomingPayload(rabbitMessage);
-    if (!payload.data || !payload.meta) {
-      throw new MessageParsingBlinkError('No data in message', payload);
-    }
-
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const message = new FreeFormMessage({
-      data: payload.data,
-      meta: payload.meta,
-    });
-    message.fields = rabbitMessage.fields;
-    return message;
   }
 }
 

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -113,7 +113,7 @@ class Message {
   }
 
   /**
-   * Dynamicly create a new instance of the concrete message class.
+   * Dynamically create a new instance of the concrete message class.
    *
    * This function automatically figures out on what of concrete message
    * subclasses one of static factory methods has been called and dynamically
@@ -124,8 +124,8 @@ class Message {
    * heuristicMessageFactory() method lives in its superclass, Message.
    *
    * This feature depends on the property of `this` context
-   * inside of static method to have `prototype` property
-   * that is a class on which static method is called.
+   * inside of a static method to have `prototype` property
+   * that is the class on which static method is called.
    * For example:
    *
    * ```
@@ -138,7 +138,7 @@ class Message {
    * SpecificMessage.printClassName(); // prints 'SpecificMessage'
    * ```
    *
-   * @param  {Object} messageData The message data, see consturctor()
+   * @param  {Object} messageData The message data, see constructor()
    * @return {this.prototype}  A new instance of the concrete message class.
    */
   static heuristicMessageFactory(messageData = {}) {

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -84,6 +84,13 @@ class Message {
         request_id: ctx.id,
       },
     };
+
+    // Save GET params when present.
+    // TODO: only save whitelsited query params?
+    if (ctx.query && Object.keys(ctx.query).length) {
+      messageData.meta.query = ctx.query;
+    }
+
     return this.heuristicMessageFactory(messageData);
   }
 
@@ -105,6 +112,35 @@ class Message {
     return message;
   }
 
+  /**
+   * Dynamicly create a new instance of the concrete message class.
+   *
+   * This function automatically figures out on what of concrete message
+   * subclasses one of static factory methods has been called and dynamically
+   * creates a new instance of it.
+   *
+   * For example FreeFormMessage.heuristicMessageFactory({}) will return
+   * an instance of FreeFormMessage. Despite the fact that actual
+   * heuristicMessageFactory() method lives in its superclass, Message.
+   *
+   * This feature depends on the property of `this` context
+   * inside of static method to have `prototype` property
+   * that is a class on which static method is called.
+   * For example:
+   *
+   * ```
+   * class Message {
+   *   static printClassName() {
+   *     console.log(this.prototype.constructor.name);
+   *   }
+   * }
+   * class SpecificMessage extends Message {}
+   * SpecificMessage.printClassName(); // prints 'SpecificMessage'
+   * ```
+   *
+   * @param  {Object} messageData The message data, see consturctor()
+   * @return {this.prototype}  A new instance of the concrete message class.
+   */
   static heuristicMessageFactory(messageData = {}) {
     return new this.prototype.constructor(messageData);
   }

--- a/src/messages/TwilioStatusCallbackMessage.js
+++ b/src/messages/TwilioStatusCallbackMessage.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 
 const Message = require('./Message');
-const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 
 class TwilioStatusCallbackMessage extends Message {
   constructor(...args) {
@@ -20,43 +19,6 @@ class TwilioStatusCallbackMessage extends Message {
 
   isDelivered() {
     return this.getData().MessageStatus === 'delivered';
-  }
-
-  static fromCtx(ctx) {
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-
-    const meta = {
-      request_id: ctx.id,
-    };
-
-    // Save GET params when present.
-    // TODO: move to generic function for all messages?
-    if (ctx.query && Object.keys(ctx.query).length) {
-      meta.query = ctx.query;
-    }
-
-    const message = new TwilioStatusCallbackMessage({
-      data: ctx.request.body,
-      meta,
-    });
-    return message;
-  }
-
-  static fromRabbitMessage(rabbitMessage) {
-    const payload = this.parseIncomingPayload(rabbitMessage);
-    if (!payload.data || !payload.meta) {
-      throw new MessageParsingBlinkError('No data in message', payload);
-    }
-
-    // TODO: save more metadata
-    // TODO: metadata parse helper
-    const message = new TwilioStatusCallbackMessage({
-      data: payload.data,
-      meta: payload.meta,
-    });
-    message.fields = rabbitMessage.fields;
-    return message;
   }
 }
 

--- a/test/unit/lib/Dequeuer.test.js
+++ b/test/unit/lib/Dequeuer.test.js
@@ -186,7 +186,7 @@ test('Dequeuer.extractOrDiscard(): ensure nack on incorrect JSON payload', (t) =
   const nackStub = sinon.stub(queue, 'nack').returns(null);
 
   // Ensure Message.fromRabbitMessage throws MessageParsingBlinkError
-  const blinkParsingErrorSpy = sinon.spy(queue.messageClass, 'parseIncomingPayload');
+  const blinkParsingErrorSpy = sinon.spy(queue.messageClass, 'unpackRabbitMessage');
 
   // Create deliberaly incorrect JSON and feed it to extractOrDiscard.
   const rabbitMessage = MessageFactoryHelper.getFakeRabbitMessage('{incorrect-json}');

--- a/test/unit/messages/Message.test.js
+++ b/test/unit/messages/Message.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+
+const Message = require('../../../src/messages/Message');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+
+// ------- Tests ---------------------------------------------------------------
+
+/**
+ * Message.heuristicMessageFactory()
+ */
+test('Message.heuristicMessageFactory(): Should correctly detect concrete message classes', () => {
+  class CustomMessageClass extends Message {
+    // Dummy method to ensure it's callable when the class is instantiated heuristically.
+    myConcreteMethod() { return this.getData(); }
+  }
+  const customMessage = CustomMessageClass.heuristicMessageFactory({});
+  customMessage.should.be.an.instanceof(CustomMessageClass);
+  customMessage.should.be.an.instanceof(Message);
+  customMessage.should.respondTo('myConcreteMethod');
+});
+
+// ------- End -----------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
This PR makes it optional to create `fromCtx()` and `fromRabbitMessage()` from extending from `Message` class. Both these methods are moved to `Message` class itself, which dynamically figures out what concrete class to create.
Also, this PR will automatically save GET data to message metadata. Before that this only worked in `TwilioStatusCallbackMessage`

#### How should this be manually tested?
- `yarn install`
- `docker-compose up`
- `yarn test:full`

#### Any background context you want to provide?
This feature depends on the property of `this` context inside of a static method to have `prototype` property that is the class on which static method is called.

For example:

```js
class Message {
  static printClassName() {
    console.log(this.prototype.constructor.name);
  }
}
class SpecificMessage extends Message {}
SpecificMessage.printClassName(); // prints 'SpecificMessage'
```