### PR TITLE
add fail injection parsing to Blink CustomerIoSmsBroadcastRelayWorker

### DIFF
--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -37,6 +37,10 @@ class Message {
     return this.payload.meta.request_id;
   }
 
+  getQueryParams() {
+    return this.payload.meta.query;
+  }
+
   getRetryAttempt() {
     return this.payload.meta.retryAttempt || 0;
   }

--- a/src/workers/CustomerIoSmsBroadcastRelayWorker.js
+++ b/src/workers/CustomerIoSmsBroadcastRelayWorker.js
@@ -151,6 +151,7 @@ class CustomerIoSmsBroadcastRelayWorker extends Worker {
   }
 
   getRequestHeaders(message) {
+    const queryParams = message.getQueryParams();
     const headers = {
       Authorization: `Basic ${this.apiKey}`,
       'X-Request-ID': message.getRequestId(),
@@ -161,6 +162,12 @@ class CustomerIoSmsBroadcastRelayWorker extends Worker {
       headers['x-blink-retry-count'] = message.getRetryAttempt();
     }
 
+    // Fail injection through query params.
+    // It converts them to headers before sending request to Conversations.
+    if (queryParams.requestFail) {
+      headers['x-request-fail'] = 'true';
+      headers['x-request-fail-count'] = queryParams.requestFailCount || '1';
+    }
     return headers;
   }
 

--- a/src/workers/CustomerIoSmsBroadcastRelayWorker.js
+++ b/src/workers/CustomerIoSmsBroadcastRelayWorker.js
@@ -151,7 +151,7 @@ class CustomerIoSmsBroadcastRelayWorker extends Worker {
   }
 
   getRequestHeaders(message) {
-    const queryParams = message.getQueryParams();
+    const queryParams = message.getQueryParams() || {};
     const headers = {
       Authorization: `Basic ${this.apiKey}`,
       'X-Request-ID': message.getRequestId(),


### PR DESCRIPTION
#### What's this PR do?
Adds the capability to control (fail) requests based on query string.

When the Customer.io broadcast request contains the query parameters `requestFail` and  `requestFailCount` (Example: `requestFail=true&requestFailCount=1`), it will inject `x-request-fail` and `x-request-fail-count` headers to the request relayed to G-Con.

#### How should this be reviewed?
- 👀 

#### Any background context you want to provide?
- I need this feature to hand pick requests to fail while load testing. This will help stress the new Blink retries mechanism.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.

  