### PR TITLE
Gambit Broadcast webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ NEW_RELIC_ENABLED=false
 GAMBIT_API_BASE_URL=http://localhost:5000/v1
 GAMBIT_API_KEY=totallysecret
 # Conversations
-GAMBIT_CONVERSATIONS_BASE_URL=http://localhost:5100/api/v1
+GAMBIT_CONVERSATIONS_BASE_URL=http://localhost:5100/api
 GAMBIT_CONVERSATIONS_API_KEY=dG90YWxseXNlY3JldA==
 
 # Customer.io

--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,15 @@ BLINK_APP_DEFAULT_RETRY_LIMIT=18000
 NEW_RELIC_NO_CONFIG_FILE=true
 NEW_RELIC_ENABLED=false
 
-# Gambit
+# Gambit Campaigns - deprecated?
 GAMBIT_API_BASE_URL=http://localhost:5000/v1
 GAMBIT_API_KEY=totallysecret
-# Conversations
-GAMBIT_CONVERSATIONS_BASE_URL=http://localhost:5100/api
+
+# Gambit Conversations
 GAMBIT_CONVERSATIONS_API_KEY=dG90YWxseXNlY3JldA==
+GAMBIT_CONVERSATIONS_API_BASEURI==http://localhost:5100/api/v2
+# v1 var to be deprecated
+GAMBIT_CONVERSATIONS_BASE_URL=http://localhost:5100/api/v1
 
 # Customer.io
 # See https://fly.customer.io/account/customerio_integration

--- a/Procfile
+++ b/Procfile
@@ -2,9 +2,10 @@ web: npm run web
 fetch: npm run worker fetch
 customer-io-campaign-signup-post: npm run worker customer-io-campaign-signup-post
 customer-io-campaign-signup: npm run worker customer-io-campaign-signup
-customer-io-sms-broadcast-relay: npm run worker customer-io-sms-broadcast-relay
+customer-io-gambit-broadcast: npm run worker customer-io-gambit-broadcast
 customer-io-update-customer: npm run worker customer-io-update-customer
 gambit-campaign-signup-relay: npm run worker gambit-campaign-signup-relay
-twilio-sms-broadcast-gambit-relay: npm run worker twilio-sms-broadcast-gambit-relay
 twilio-sms-inbound-gambit-relay: npm run worker twilio-sms-inbound-gambit-relay
 redis-retries-republish: npm run timer redis-retries-republish
+customer-io-sms-broadcast-relay: npm run worker customer-io-sms-broadcast-relay
+twilio-sms-broadcast-gambit-relay: npm run worker twilio-sms-broadcast-gambit-relay

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -2,6 +2,7 @@
 
 const config = {
   conversationsBaseUri: process.env.GAMBIT_CONVERSATIONS_API_BASEURI || 'http://localhost:5100/api/v2',
+  // TODO: Fix this typo.
   converationsApiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
   broadcastSpeedLimit: process.env.GAMBIT_BROADCAST_SPEED_LIMIT || 50,
   // Conversations v1 URL to be deprecated:

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const config = {
-  baseUrl: process.env.GAMBIT_API_BASE_URL || 'http://localhost:5000/v1',
-  apiKey: process.env.GAMBIT_API_KEY || 'totallysecret',
-  converationsBaseUrl: process.env.GAMBIT_CONVERSATIONS_BASE_URL || 'http://localhost:5100/api/v1',
+  conversationsBaseUri: process.env.GAMBIT_CONVERSATIONS_API_BASEURI || 'http://localhost:5100/api/v2',
   converationsApiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
   broadcastSpeedLimit: process.env.GAMBIT_BROADCAST_SPEED_LIMIT || 50,
+  // Conversations v1 URL to be deprecated:
+  converationsBaseUrl: process.env.GAMBIT_CONVERSATIONS_BASE_URL || 'http://localhost:5100/api/v1',
+  // Gambit Campaigns variables to be deprecated:
+  baseUrl: process.env.GAMBIT_API_BASE_URL || 'http://localhost:5000/v1',
+  apiKey: process.env.GAMBIT_API_KEY || 'totallysecret',
 };
 
 module.exports = config;

--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -14,6 +14,7 @@ const RedisConnectionManager = require('../lib/RedisConnectionManager');
 // Queues.
 const CustomerIoCampaignSignupPostQ = require('../queues/CustomerIoCampaignSignupPostQ');
 const CustomerIoCampaignSignupQ = require('../queues/CustomerIoCampaignSignupQ');
+const CustomerioGambitBroadcastQ = require('../queues/CustomerioGambitBroadcastQ');
 const CustomerioSmsBroadcastRelayQ = require('../queues/CustomerioSmsBroadcastRelayQ');
 const CustomerIoUpdateCustomerQ = require('../queues/CustomerIoUpdateCustomerQ');
 const FetchQ = require('../queues/FetchQ');
@@ -157,6 +158,7 @@ class BlinkApp {
     return [
       CustomerIoCampaignSignupPostQ,
       CustomerIoCampaignSignupQ,
+      CustomerioGambitBroadcastQ,
       CustomerioSmsBroadcastRelayQ,
       CustomerIoUpdateCustomerQ,
       FetchQ,

--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -84,6 +84,11 @@ class BlinkWebApp extends BlinkApp {
       webHooksWebController.customerioEmailActivity,
     );
     router.post(
+      'api.v1.webhooks.customerio-gambit-broadcast',
+      '/api/v1/webhooks/customerio-gambit-broadcast',
+      webHooksWebController.customerioGambitBroadcast,
+    );
+    router.post(
       'api.v1.webhooks.customerio-sms-broadcast',
       '/api/v1/webhooks/customerio-sms-broadcast',
       webHooksWebController.customerioSmsBroadcast,

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -3,6 +3,7 @@
 const BlinkError = require('../errors/BlinkError');
 const CustomerIoCampaignSignupPostWorker = require('../workers/CustomerIoCampaignSignupPostWorker');
 const CustomerIoCampaignSignupWorker = require('../workers/CustomerIoCampaignSignupWorker');
+const CustomerIoGambitBroadcastWorker = require('../workers/CustomerIoGambitBroadcastWorker');
 const CustomerIoSmsBroadcastRelayWorker = require('../workers/CustomerIoSmsBroadcastRelayWorker');
 const CustomerIoUpdateCustomerWorker = require('../workers/CustomerIoUpdateCustomerWorker');
 const FetchWorker = require('../workers/FetchWorker');
@@ -43,6 +44,7 @@ class BlinkWorkerApp extends BlinkApp {
       fetch: FetchWorker,
       'customer-io-campaign-signup': CustomerIoCampaignSignupWorker,
       'customer-io-campaign-signup-post': CustomerIoCampaignSignupPostWorker,
+      'customer-io-gambit-broadcast': CustomerIoGambitBroadcastWorker,
       'customer-io-sms-broadcast-relay': CustomerIoSmsBroadcastRelayWorker,
       'customer-io-update-customer': CustomerIoUpdateCustomerWorker,
       'gambit-campaign-signup-relay': GambitCampaignSignupRelayWorker,

--- a/src/messages/CustomerioGambitBroadcastMessage.js
+++ b/src/messages/CustomerioGambitBroadcastMessage.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Joi = require('joi');
+
+const Message = require('./Message');
+
+class CustomerioGambitBroadcastMessage extends Message {
+  constructor(...args) {
+    super(...args);
+
+    const whenNullOrEmpty = Joi.valid(['', null]);
+    this.schema = Joi.object()
+      .keys({
+        // Note: first char of To is plus, which is resolved to a space by mistake.
+        mobile: Joi.string().required().empty(whenNullOrEmpty).regex(/^\+1[0-9]+$/, 'valid phone number'),
+        broadcastId: Joi.string().required().empty(whenNullOrEmpty),
+      });
+  }
+
+  getBroadcastId() {
+    return this.getData().broadcastId;
+  }
+
+  getPhoneNumber() {
+    return this.getData().mobile;
+  }
+}
+
+module.exports = CustomerioGambitBroadcastMessage;

--- a/src/messages/CustomerioGambitBroadcastMessage.js
+++ b/src/messages/CustomerioGambitBroadcastMessage.js
@@ -11,8 +11,7 @@ class CustomerioGambitBroadcastMessage extends Message {
     const whenNullOrEmpty = Joi.valid(['', null]);
     this.schema = Joi.object()
       .keys({
-        // Note: first char of To is plus, which is resolved to a space by mistake.
-        mobile: Joi.string().required().empty(whenNullOrEmpty).regex(/^\+1[0-9]+$/, 'valid phone number'),
+        northstarId: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
         broadcastId: Joi.string().required().empty(whenNullOrEmpty),
       });
   }
@@ -21,8 +20,8 @@ class CustomerioGambitBroadcastMessage extends Message {
     return this.getData().broadcastId;
   }
 
-  getPhoneNumber() {
-    return this.getData().mobile;
+  getNorthstarId() {
+    return this.getData().northstarId;
   }
 }
 

--- a/src/queues/CustomerioGambitBroadcastQ.js
+++ b/src/queues/CustomerioGambitBroadcastQ.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const CustomerioGambitBroadcastMessage = require('../messages/CustomerioGambitBroadcastMessage');
+const Queue = require('../lib/Queue');
+
+class CustomerioGambitBroadcastQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.messageClass = CustomerioGambitBroadcastMessage;
+  }
+}
+
+module.exports = CustomerioGambitBroadcastQ;

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const CustomerioGambitBroadcastMessage = require('../../messages/CustomerioGambitBroadcastMessage');
 const CustomerioSmsBroadcastMessage = require('../../messages/CustomerioSmsBroadcastMessage');
 const CustomerIoWebhookMessage = require('../../messages/CustomerIoWebhookMessage');
 const FreeFormMessage = require('../../messages/FreeFormMessage');
@@ -12,14 +13,17 @@ class WebHooksWebController extends WebController {
     // Bind web methods to object context so they can be passed to router.
     this.index = this.index.bind(this);
     this.customerioEmailActivity = this.customerioEmailActivity.bind(this);
+    this.customerioGambitBroadcast = this.customerioGambitBroadcast.bind(this);
+    this.twilioSmsInbound = this.twilioSmsInbound.bind(this);
+    // To be / currently deprecated
     this.customerioSmsBroadcast = this.customerioSmsBroadcast.bind(this);
     this.twilioSmsBroadcast = this.twilioSmsBroadcast.bind(this);
-    this.twilioSmsInbound = this.twilioSmsInbound.bind(this);
   }
 
   async index(ctx) {
     ctx.body = {
       'customerio-email-activity': this.fullUrl('api.v1.webhooks.customerio-email-activity'),
+      'customerio-gambit-broadcast': this.fullUrl('api.v1.webhooks.customerio-gambit-broadcast'),
       'customerio-sms-broadcast': this.fullUrl('api.v1.webhooks.customerio-sms-broadcast'),
       'twilio-sms-broadcast': this.fullUrl('api.v1.webhooks.twilio-sms-broadcast'),
       'twilio-sms-inbound': this.fullUrl('api.v1.webhooks.twilio-sms-inbound'),
@@ -33,6 +37,18 @@ class WebHooksWebController extends WebController {
       const { quasarCustomerIoEmailActivityQ } = this.blink.queues;
       quasarCustomerIoEmailActivityQ.publish(customerIoWebhookMessage);
       this.sendOK(ctx, customerIoWebhookMessage);
+    } catch (error) {
+      this.sendError(ctx, error);
+    }
+  }
+
+  async customerioGambitBroadcast(ctx) {
+    try {
+      const message = CustomerioGambitBroadcastMessage.fromCtx(ctx);
+      message.validate();
+      const { customerioGambitBroadcastQ } = this.blink.queues;
+      customerioGambitBroadcastQ.publish(message);
+      this.sendOK(ctx, message, 201);
     } catch (error) {
       this.sendError(ctx, error);
     }

--- a/src/workers/CustomerIoGambitBroadcastWorker.js
+++ b/src/workers/CustomerIoGambitBroadcastWorker.js
@@ -13,7 +13,7 @@ class CustomerIoGambitBroadcastWorker extends Worker {
       rateLimit: this.blink.config.gambit.broadcastSpeedLimit,
     });
     // Setup Gambit.
-    this.baseURL = this.blink.config.gambit.converationsBaseUrl;
+    this.baseURI = this.blink.config.gambit.converationsBaseUri;
     this.apiKey = this.blink.config.gambit.converationsApiKey;
   }
 
@@ -28,7 +28,7 @@ class CustomerIoGambitBroadcastWorker extends Worker {
     const body = JSON.stringify(data);
     const headers = this.getRequestHeaders(message);
     const response = await fetch(
-      `${this.baseURL}/v2/messages?origin=broadcast`,
+      `${this.baseURI}/messages?origin=broadcast`,
       {
         method: 'POST',
         headers,

--- a/src/workers/CustomerIoGambitBroadcastWorker.js
+++ b/src/workers/CustomerIoGambitBroadcastWorker.js
@@ -13,7 +13,7 @@ class CustomerIoGambitBroadcastWorker extends Worker {
       rateLimit: this.blink.config.gambit.broadcastSpeedLimit,
     });
     // Setup Gambit.
-    this.baseURI = this.blink.config.gambit.converationsBaseUri;
+    this.baseURI = this.blink.config.gambit.conversationsBaseUri;
     this.apiKey = this.blink.config.gambit.converationsApiKey;
   }
 
@@ -22,7 +22,7 @@ class CustomerIoGambitBroadcastWorker extends Worker {
     // errored after the request, sending a double post.
 
     const data = {
-      mobile: message.getPhoneNumber(),
+      northstarId: message.getNorthstarId(),
       broadcastId: message.getBroadcastId(),
     };
     const body = JSON.stringify(data);

--- a/src/workers/CustomerIoSmsBroadcastRelayWorker.js
+++ b/src/workers/CustomerIoSmsBroadcastRelayWorker.js
@@ -75,7 +75,7 @@ class CustomerIoSmsBroadcastRelayWorker extends Worker {
     const body = JSON.stringify(data);
     const headers = this.getRequestHeaders(message);
     const response = await fetch(
-      `${this.baseURL}/v1/import-message?broadcastId=${message.getBroadcastId()}`,
+      `${this.baseURL}/import-message?broadcastId=${message.getBroadcastId()}`,
       {
         method: 'POST',
         headers,

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -253,9 +253,14 @@ class MessageFactoryHelper {
     return rabbitMessage;
   }
 
+  static getFakeMobileNumber() {
+    const result = `+1555${chance.string({ length: 7, pool: '1234567890' })}`;
+    return result;
+  }
+
   static getValidCustomerBroadcastData(broadcastId) {
     const data = {
-      To: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
+      To: MessageFactoryHelper.getFakeMobileNumber(),
       Body: chance.sentence(),
       StatusCallback: `http://blink:password@blink.dosomething.org/api/v1/webhooks/twilio-sms-broadcast?broadcastId=${broadcastId}`,
     };
@@ -264,7 +269,7 @@ class MessageFactoryHelper {
 
   static getValidGambitBroadcastData(broadcastId) {
     const data = {
-      mobile: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
+      mobile: MessageFactoryHelper.getFakeMobileNumber(),
       broadcastId,
     };
     return data;

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -261,6 +261,14 @@ class MessageFactoryHelper {
     };
     return data;
   }
+
+  static getValidGambitBroadcastData(broadcastId) {
+    const data = {
+      mobile: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
+      broadcastId,
+    };
+    return data;
+  }
 }
 
 module.exports = MessageFactoryHelper;

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -20,7 +20,7 @@ const chance = new Chance();
 
 class MessageFactoryHelper {
   static getValidUser() {
-    const fakeId = chance.hash({ length: 24 });
+    const fakeId = MessageFactoryHelper.getFakeUserId();
     const createdAt = chance.date({ year: chance.year({ min: 2000, max: 2010 }) }).toISOString();
     return new UserMessage({
       data: {
@@ -71,7 +71,7 @@ class MessageFactoryHelper {
   }
 
   static getValidCustomerIoIdentify() {
-    const fakeId = chance.hash({ length: 24 });
+    const fakeId = MessageFactoryHelper.getFakeUserId();
     return new CustomerIoUpdateCustomerMessage({
       data: {
         id: fakeId,
@@ -258,6 +258,11 @@ class MessageFactoryHelper {
     return result;
   }
 
+  static getFakeUserId() {
+    const result = chance.hash({ length: 24 });
+    return result;
+  }
+
   static getValidCustomerBroadcastData(broadcastId) {
     const data = {
       To: MessageFactoryHelper.getFakeMobileNumber(),
@@ -269,7 +274,7 @@ class MessageFactoryHelper {
 
   static getValidGambitBroadcastData(broadcastId) {
     const data = {
-      mobile: MessageFactoryHelper.getFakeMobileNumber(),
+      northstarId: MessageFactoryHelper.getFakeUserId(),
       broadcastId,
     };
     return data;

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -155,7 +155,7 @@ test('POST /api/v1/webhooks/customerio-sms-broadcast validates incoming payload'
 test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming payload', async (t) => {
   const broadcastId = chance.word();
   const data = MessageFactoryHelper.getValidGambitBroadcastData(broadcastId);
-  delete data.mobile;
+  delete data.northstarId;
 
   const res = await t.context.supertest.post('/api/v1/webhooks/customerio-gambit-broadcast')
     .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -165,7 +165,7 @@ test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming paylo
   res.status.should.be.equal(422);
   res.body.should.have.property('ok', false);
   res.body.should.have.property('message')
-    .and.have.string('"mobile" is required');
+    .and.have.string('"northstarId" is required');
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -38,12 +38,17 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
   res.body.should.have.property('customerio-email-activity')
     .and.have.string('/api/v1/webhooks/customerio-email-activity');
 
+  // Should be deprecated:
   res.body.should.have.property('twilio-sms-broadcast')
     .and.have.string('/api/v1/webhooks/twilio-sms-broadcast');
 
   res.body.should.have.property('twilio-sms-inbound')
     .and.have.string('/api/v1/webhooks/twilio-sms-inbound');
 
+  res.body.should.have.property('customerio-gambit-broadcast')
+    .and.have.string('/api/v1/webhooks/customerio-gambit-broadcast');
+
+  // To be deprecated
   res.body.should.have.property('customerio-sms-broadcast')
     .and.have.string('/api/v1/webhooks/customerio-sms-broadcast');
 });
@@ -142,6 +147,25 @@ test('POST /api/v1/webhooks/customerio-sms-broadcast validates incoming payload'
   res.body.should.have.property('ok', false);
   res.body.should.have.property('message')
     .and.have.string('"To" is required');
+});
+
+/**
+ * POST /api/v1/webhooks/customerio-gambit-broadcast
+ */
+test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming payload', async (t) => {
+  const broadcastId = chance.word();
+  const data = MessageFactoryHelper.getValidGambitBroadcastData(broadcastId);
+  delete data.mobile;
+
+  const res = await t.context.supertest.post('/api/v1/webhooks/customerio-gambit-broadcast')
+    .set('Content-Type', 'application/x-www-form-urlencoded')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(422);
+  res.body.should.have.property('ok', false);
+  res.body.should.have.property('message')
+    .and.have.string('"mobile" is required');
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/unit/queues/CustomerioGambitBroadcastQ.test.js
+++ b/test/unit/queues/CustomerioGambitBroadcastQ.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+
+const Broker = require('../../../src/lib/brokers/Broker');
+const Queue = require('../../../src/lib/Queue');
+const CustomerioGambitBroadcastQ = require('../../../src/queues/CustomerioGambitBroadcastQ');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+
+// ------- Tests ---------------------------------------------------------------
+
+/**
+ * Test CustomerioSmsBroadcastRelayQ
+ */
+test('CustomerioGambitBroadcastQ', () => {
+  const queue = new CustomerioGambitBroadcastQ(new Broker());
+  queue.should.be.an.instanceof(Queue);
+  queue.routes.should.include('customerio-gambit-broadcast');
+});
+
+// ------- End -----------------------------------------------------------------


### PR DESCRIPTION
First pass at a `CustomerIoGambitBroadcast` resource, based off of the `CustomerioSmsBroadcast`, to deliver broadcast messages via Gambit Conversations `POST /v2/messages?origin=broadcast` (https://github.com/DoSomething/gambit-conversations/pull/272)

🍔 for 💭 - 
* Went with `Gambit` instead of `Sms`, as ideally we'd add a platform parameter, to use one queue for broadcasts over multiple platforms (e.g. FB Messenger).

 * I've named it with the CustomerIo prefix for now, but keep thinking about calling it `GambitBroadcast` vs `CustomerIoGambitBroadcast`.. which would make it more of an event than a webhook. Would each service that can send a broadcast get its own queue? (similar to previous naming decision on `GambitBroadcast` vs `GambitSmsBroadcast`

 Cleanup TODOs for the future:

* After go live with v2 broadcasts, remove the `CustomerioSmsBroadcast` and `TwilioSmsBroadcastGambitRelayWorker` resources
* Remove deprecated Gambit Campaigns config vars