### PR TITLE
Bumped version to 2.0.1. Added .wercker to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ jspm_packages
 
 # Dot env
 .env
+
+# wercker
+.wercker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.1",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
     "node": "8.9.3",


### PR DESCRIPTION
#### What's this PR do?
- Updates the versioning that I missed in latest release.
- Adds `.wercker` files to the `.gitignore` list.


#### How to review this PR?
- 👀 