### PR TITLE
removed unnecessary validations in CampaignSignupPost Message.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "promise-throttle": "^0.3.1",
     "throng": "^4.0.0",
     "twilio": "^3.10.1",
+    "underscore": "^1.8.3",
     "uuid": "^3.1.0",
     "winston": "^2.4.0",
     "yargs": "^10.0.3"

--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -35,6 +35,12 @@ class CampaignSignupPostMessage extends Message {
      * from the final eventData Object
      */
     const cioKeys = {
+
+      /**
+       * The Rogue data object's `id` property, maps to the C.io's `signup_post_id`.
+       * The final event posted to C.io contains a `signup_post_id` instead of
+       * the original `id` property.
+       */
       signup_post_id: 'id',
     };
 

--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -29,9 +29,9 @@ class CampaignSignupPostMessage extends Message {
     const data = this.getData();
 
     /**
-     * cioKey: dataKey Mappings
+     * { cioKey: dataKey } Mappings
      *
-     * cioKeys will be assigned dataKeys and dataKeys will be deleted
+     * cioKeys will be assigned dataKey's value and dataKeys will be deleted
      * from the final eventData Object
      */
     const cioKeys = {
@@ -49,7 +49,7 @@ class CampaignSignupPostMessage extends Message {
     });
 
     /**
-     * Assign dataKey values to the corresponsing cioKey
+     * Assign dataKey values to the corresponding cioKey
      * Remove dataKey from eventData
      */
     Object.keys(cioKeys).forEach((cioKey) => {

--- a/src/validations/campaignSignupPost.js
+++ b/src/validations/campaignSignupPost.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Joi = require('joi');
+
+const whenNullOrEmpty = Joi.valid(['', null]);
+
+// Required minimum.
+const schema = Joi.object()
+  .keys({
+    id: Joi.required().empty(whenNullOrEmpty),
+    signup_id: Joi.required().empty(whenNullOrEmpty),
+    campaign_id: Joi.string().required().empty(whenNullOrEmpty),
+    northstar_id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
+    type: Joi.string().required().empty(whenNullOrEmpty),
+    action: Joi.string().required().empty(whenNullOrEmpty),
+    created_at: Joi.string().required().empty(whenNullOrEmpty).isoDate(), // Time stamp.
+  });
+
+module.exports = schema;

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -57,7 +57,7 @@ class EventsWebController extends WebController {
   async userSignupPost(ctx) {
     try {
       const message = CampaignSignupPostMessage.fromCtx(ctx);
-      message.validateStrict();
+      message.validate();
       this.blink.broker.publishToRoute(
         'signup-post.user.event',
         message,

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -169,13 +169,16 @@ class MessageFactoryHelper {
       id: chance.integer({ min: 0 }),
       signup_id: chance.integer({ min: 0 }),
       northstar_id: chance.hash({ length: 24 }),
-      campaign_id: chance.string({ length: 4, pool: '1234567890' }),
+      campaign_id: chance.pickone([
+        chance.integer({ min: 0 }),
+        chance.string({ length: 4, pool: '1234567890' }),
+      ]),
       type: chance.pickone(['photo', 'voter-reg']),
       action: chance.pickone(['january2018-turbovote', 'january-submit-photo']),
       created_at: createdAt,
 
       // Optional / nullable
-      campaign_run_id: chance.pickone([null, 99, 'abc99']),
+      campaign_run_id: chance.pickone([null, chance.integer({ min: 0 })]),
       source: chance.pickone([null, 'campaigns', 'phoenix-web']),
       media: chance.pickone([null, {
         url: chance.avatar({ protocol: 'https' }),

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -165,7 +165,7 @@ class MessageFactoryHelper {
     const deletedAt = moment(createdAt).add(2, 'days').toISOString();
 
     const data = {
-      // Required minimunm
+      // Required minimum
       id: chance.integer({ min: 0 }),
       signup_id: chance.integer({ min: 0 }),
       northstar_id: chance.hash({ length: 24 }),
@@ -185,7 +185,7 @@ class MessageFactoryHelper {
         caption: chance.sentence({ words: 5 }),
       }]),
       why_participated: chance.pickone([null, chance.sentence()]),
-      updatead_at: chance.pickone([null, updatedAt]),
+      updated_at: chance.pickone([null, updatedAt]),
       deleted_at: chance.pickone([null, deletedAt]),
       details: chance.pickone([null, { random: 'stuff' }]),
       remote_addr: chance.pickone([null, chance.ip()]),

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -169,10 +169,7 @@ class MessageFactoryHelper {
       id: chance.integer({ min: 0 }),
       signup_id: chance.integer({ min: 0 }),
       northstar_id: chance.hash({ length: 24 }),
-      campaign_id: chance.pickone([
-        chance.integer({ min: 0 }),
-        chance.string({ length: 4, pool: '1234567890' }),
-      ]),
+      campaign_id: chance.string({ length: 4, pool: '1234567890' }),
       type: chance.pickone(['photo', 'voter-reg']),
       action: chance.pickone(['january2018-turbovote', 'january-submit-photo']),
       created_at: createdAt,

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -162,40 +162,36 @@ class MessageFactoryHelper {
   static getValidCampaignSignupPost() {
     const createdAt = chance.date({ year: (new Date()).getFullYear() }).toISOString();
     const updatedAt = moment(createdAt).add(1, 'days').toISOString();
+    const deletedAt = moment(createdAt).add(2, 'days').toISOString();
 
     const data = {
-      // Required
+      // Required minimunm
       id: chance.integer({ min: 0 }),
       signup_id: chance.integer({ min: 0 }),
       northstar_id: chance.hash({ length: 24 }),
       campaign_id: chance.string({ length: 4, pool: '1234567890' }),
-      campaign_run_id: chance.string({ length: 4, pool: '1234567890' }),
-      quantity: chance.integer({ min: 0 }),
-
-      // Optional
-      source: chance.pickone(['campaigns', 'phoenix-web']),
-      caption: chance.sentence({ words: 5 }),
-      why_participated: chance.sentence(),
-      url: chance.avatar({ protocol: 'https' }),
-
-      // Timestamps
+      type: chance.pickone(['photo', 'voter-reg']),
+      action: chance.pickone(['january2018-turbovote', 'january-submit-photo']),
       created_at: createdAt,
-      updatead_at: updatedAt,
-      deleted_at: null,
-    };
 
-    // Optional, may be empty.
-    const optionalFields = [
-      'source',
-      'caption',
-      'why_participated',
-      'url',
-    ];
-    optionalFields.forEach((key) => {
-      if (chance.bool({ likelihood: 40 })) {
-        delete data[key];
-      }
-    });
+      // Optional / nullable
+      campaign_run_id: chance.pickone([null, 99, 'abc99']),
+      source: chance.pickone([null, 'campaigns', 'phoenix-web']),
+      media: chance.pickone([null, {
+        url: chance.avatar({ protocol: 'https' }),
+        caption: chance.sentence({ words: 5 }),
+      }]),
+      why_participated: chance.pickone([null, chance.sentence()]),
+      updatead_at: chance.pickone([null, updatedAt]),
+      deleted_at: chance.pickone([null, deletedAt]),
+      details: chance.pickone([null, { random: 'stuff' }]),
+      remote_addr: chance.pickone([null, chance.ip()]),
+      tags: chance.pickone([null, [], ['stuff', 'more-stuff']]),
+      status: chance.pickone([null, 'pending']),
+      quantity: chance.pickone([null, chance.integer({
+        min: 1, max: 10,
+      })]),
+    };
 
     return new CampaignSignupPostMessage({
       data,

--- a/test/integration/web/controllers/EventsWebController.test.js
+++ b/test/integration/web/controllers/EventsWebController.test.js
@@ -235,23 +235,9 @@ test('POST /api/v1/events/user-signup-post should publish message to user-signup
   // Required.
   messageData.data.id.should.be.eql(data.id);
   messageData.data.campaign_id.should.be.eql(data.campaign_id);
-  messageData.data.campaign_run_id.should.be.eql(data.campaign_run_id);
   messageData.data.northstar_id.should.be.eql(data.northstar_id);
   messageData.data.signup_id.should.be.eql(data.signup_id);
   messageData.data.created_at.should.be.eql(data.created_at);
-
-  // Optional.
-  const optionalFields = [
-    'source',
-    'caption',
-    'why_participated',
-    'url',
-  ];
-  optionalFields.forEach((key) => {
-    if (messageData.data[key]) {
-      messageData.data[key].should.be.eql(data[key]);
-    }
-  });
 });
 
 

--- a/test/unit/messages/CampaignSignupPostMessage.test.js
+++ b/test/unit/messages/CampaignSignupPostMessage.test.js
@@ -40,32 +40,19 @@ test('Campaign signup post message should be correctly transformed to CustomerIo
 
     // Event data.
     const eventData = cioEvent.getData();
-    eventData.version.should.equal(2);
+    eventData.version.should.equal(3);
 
-    eventData.type.should.equal('photo');
     eventData.signup_post_id.should.equal(String(data.id));
     eventData.signup_id.should.equal(String(data.signup_id));
     eventData.campaign_id.should.equal(data.campaign_id);
-    eventData.campaign_run_id.should.equal(data.campaign_run_id);
-    eventData.quantity.should.equal(Number(data.quantity));
+
+    // If we want to test nullable properties, we need to check existence first
+    if (data.quantity) eventData.quantity.should.equal(Number(data.quantity));
 
     // Todo: make sure TZ is corrected
     const originalCreatedAt = moment(data.created_at).milliseconds(0);
     const eventCreatedAt = moment.unix(eventData.created_at);
     eventCreatedAt.toISOString().should.be.equal(originalCreatedAt.toISOString());
-
-    // Optional fields.
-    const optionalFields = [
-      'source',
-      'caption',
-      'url',
-      'why_participated',
-    ];
-    optionalFields.forEach((field) => {
-      if (data[field]) {
-        eventData[field].should.to.be.equal(data[field]);
-      }
-    });
 
     count -= 1;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4623,6 +4623,10 @@ uid2@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
 
+underscore@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
 unique-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"


### PR DESCRIPTION
## What does this PR do?

#### Validations for the `/api/v1/events/user-signup-post` route

It validates only a minimum set of required properties that the messaging team is expecting for successful segmentation. All other properties sent, aside from this subset of required props, are considered optional or nullable. More on which are considered required vs optional: [Blink Validation section](https://github.com/orgs/DoSomething/teams/team-bleed/discussions/13).

## How to test
- Run the tests and get no errors:
    - `cd` into your local Blink repo.
    - `yarn install`
    - `docker-compose up -d`
    - `yarn test:full`
    - `docker-compose down`

## Relevant Issues
Fixes #125 
Fixes #173 
Removes the quantity requirement for this route mentioned in #174 
Fixes part 1 of the Validation tasks in [Pivotal #154736700](https://www.pivotaltracker.com/story/show/154736700)

## Other tasks
- [x] Deploy to staging.
- [x] Extensive (~ 2 people) report-back (Campaign Signup Posts) events test in **staging**. cc @aaronschachter @justkika @sbsmith86 (Team Bleed). Basically, just going through a reportback and inspecting the event generated for your **staging** user in the **staging** C.io instance.
- [x] Update [CampaignSignupPostMessage Schema](https://github.com/DoSomething/blink/wiki/Message-Schemas#campaignsignuppostmessage) Wiki docs.
- [x] Test `voter-reg` type of Signup Posts in **staging**