### PR TITLE
Post Twilio messages to Conversations v2

### DIFF
--- a/config/gambit.js
+++ b/config/gambit.js
@@ -2,8 +2,7 @@
 
 const config = {
   conversationsBaseUri: process.env.GAMBIT_CONVERSATIONS_API_BASEURI || 'http://localhost:5100/api/v2',
-  // TODO: Fix this typo.
-  converationsApiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
+  conversationsApiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
   broadcastSpeedLimit: process.env.GAMBIT_BROADCAST_SPEED_LIMIT || 50,
   // Conversations v1 URL to be deprecated:
   converationsBaseUrl: process.env.GAMBIT_CONVERSATIONS_BASE_URL || 'http://localhost:5100/api/v1',

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const config = {
-  conversationsBaseUri: process.env.GAMBIT_CONVERSATIONS_API_BASEURI || 'http://localhost:5100/api/v2',
-  conversationsApiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
+  conversations: {
+    // TODO: When we drop Broadcasts v1 support: rename config variable to BASE_URL
+    // and remove v1BaseURL property.
+    baseURL: process.env.GAMBIT_CONVERSATIONS_API_BASEURI || 'http://localhost:5100/api/v2',
+    apiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
+    v1BaseURL: process.env.GAMBIT_CONVERSATIONS_BASE_URL || 'http://localhost:5100/api/v1',
+  },
   broadcastSpeedLimit: process.env.GAMBIT_BROADCAST_SPEED_LIMIT || 50,
-  // Conversations v1 URL to be deprecated:
-  converationsBaseUrl: process.env.GAMBIT_CONVERSATIONS_BASE_URL || 'http://localhost:5100/api/v1',
 };
 
 module.exports = config;

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -6,9 +6,6 @@ const config = {
   broadcastSpeedLimit: process.env.GAMBIT_BROADCAST_SPEED_LIMIT || 50,
   // Conversations v1 URL to be deprecated:
   converationsBaseUrl: process.env.GAMBIT_CONVERSATIONS_BASE_URL || 'http://localhost:5100/api/v1',
-  // Gambit Campaigns variables to be deprecated:
-  baseUrl: process.env.GAMBIT_API_BASE_URL || 'http://localhost:5000/v1',
-  apiKey: process.env.GAMBIT_API_KEY || 'totallysecret',
 };
 
 module.exports = config;

--- a/src/workers/CustomerIoGambitBroadcastWorker.js
+++ b/src/workers/CustomerIoGambitBroadcastWorker.js
@@ -14,7 +14,7 @@ class CustomerIoGambitBroadcastWorker extends Worker {
     });
     // Setup Gambit.
     this.baseURI = this.blink.config.gambit.conversationsBaseUri;
-    this.apiKey = this.blink.config.gambit.converationsApiKey;
+    this.apiKey = this.blink.config.gambit.conversationsApiKey;
   }
 
   async consume(message) {

--- a/src/workers/CustomerIoGambitBroadcastWorker.js
+++ b/src/workers/CustomerIoGambitBroadcastWorker.js
@@ -13,8 +13,8 @@ class CustomerIoGambitBroadcastWorker extends Worker {
       rateLimit: this.blink.config.gambit.broadcastSpeedLimit,
     });
     // Setup Gambit.
-    this.baseURI = this.blink.config.gambit.conversationsBaseUri;
-    this.apiKey = this.blink.config.gambit.conversationsApiKey;
+    this.baseURL = this.blink.config.gambit.conversations.baseURL;
+    this.apiKey = this.blink.config.gambit.conversations.apiKey;
   }
 
   async consume(message) {
@@ -28,7 +28,7 @@ class CustomerIoGambitBroadcastWorker extends Worker {
     const body = JSON.stringify(data);
     const headers = this.getRequestHeaders(message);
     const response = await fetch(
-      `${this.baseURI}/messages?origin=broadcast`,
+      `${this.baseURL}/messages?origin=broadcast`,
       {
         method: 'POST',
         headers,

--- a/src/workers/CustomerIoSmsBroadcastRelayWorker.js
+++ b/src/workers/CustomerIoSmsBroadcastRelayWorker.js
@@ -21,7 +21,7 @@ class CustomerIoSmsBroadcastRelayWorker extends Worker {
     );
     // Setup Gambit.
     this.baseURL = this.blink.config.gambit.converationsBaseUrl;
-    this.apiKey = this.blink.config.gambit.converationsApiKey;
+    this.apiKey = this.blink.config.gambit.conversationsApiKey;
   }
 
   async consume(message) {

--- a/src/workers/CustomerIoSmsBroadcastRelayWorker.js
+++ b/src/workers/CustomerIoSmsBroadcastRelayWorker.js
@@ -20,8 +20,8 @@ class CustomerIoSmsBroadcastRelayWorker extends Worker {
       this.blink.config.twilio.authToken,
     );
     // Setup Gambit.
-    this.baseURL = this.blink.config.gambit.converationsBaseUrl;
-    this.apiKey = this.blink.config.gambit.conversationsApiKey;
+    this.baseURL = this.blink.config.gambit.conversations.v1BaseURL;
+    this.apiKey = this.blink.config.gambit.conversations.apiKey;
   }
 
   async consume(message) {

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -13,7 +13,7 @@ class GambitCampaignSignupRelayWorker extends Worker {
     });
     // Setup Gambit configuration.
     this.baseURI = this.blink.config.gambit.conversationsBaseUri;
-    this.apiKey = this.blink.config.gambit.converationsApiKey;
+    this.apiKey = this.blink.config.gambit.conversationsApiKey;
   }
 
   async consume(message) {

--- a/src/workers/GambitCampaignSignupRelayWorker.js
+++ b/src/workers/GambitCampaignSignupRelayWorker.js
@@ -12,8 +12,8 @@ class GambitCampaignSignupRelayWorker extends Worker {
       queue: this.blink.queues.gambitCampaignSignupRelayQ,
     });
     // Setup Gambit configuration.
-    this.baseURI = this.blink.config.gambit.conversationsBaseUri;
-    this.apiKey = this.blink.config.gambit.conversationsApiKey;
+    this.baseURL = this.blink.config.gambit.conversations.baseURL;
+    this.apiKey = this.blink.config.gambit.conversations.apiKey;
   }
 
   async consume(message) {
@@ -42,7 +42,7 @@ class GambitCampaignSignupRelayWorker extends Worker {
     const headers = this.getRequestHeaders(message);
 
     const response = await fetch(
-      `${this.baseURI}/messages?origin=signup`,
+      `${this.baseURL}/messages?origin=signup`,
       {
         method: 'POST',
         headers,

--- a/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
+++ b/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
@@ -12,8 +12,8 @@ class TwilioSmsBroadcastGambitRelayWorker extends Worker {
       queue: this.blink.queues.twilioSmsBroadcastGambitRelayQ,
     });
     // Setup Gambit.
-    this.baseURL = this.blink.config.gambit.converationsBaseUrl;
-    this.apiKey = this.blink.config.gambit.conversationsApiKey;
+    this.baseURL = this.blink.config.gambit.conversations.v1BaseURL;
+    this.apiKey = this.blink.config.gambit.conversations.apiKey;
   }
 
   async consume(message) {

--- a/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
+++ b/src/workers/TwilioSmsBroadcastGambitRelayWorker.js
@@ -13,7 +13,7 @@ class TwilioSmsBroadcastGambitRelayWorker extends Worker {
     });
     // Setup Gambit.
     this.baseURL = this.blink.config.gambit.converationsBaseUrl;
-    this.apiKey = this.blink.config.gambit.converationsApiKey;
+    this.apiKey = this.blink.config.gambit.conversationsApiKey;
   }
 
   async consume(message) {

--- a/src/workers/TwilioSmsInboundGambitRelayWorker.js
+++ b/src/workers/TwilioSmsInboundGambitRelayWorker.js
@@ -12,7 +12,7 @@ class TwilioSmsInboundGambitRelayWorker extends Worker {
       queue: this.blink.queues.twilioSmsInboundGambitRelayQ,
     });
     // Setup Gambit.
-    this.baseURL = this.blink.config.gambit.converationsBaseUrl;
+    this.baseURI = this.blink.config.gambit.conversationsBaseUri;
     this.apiKey = this.blink.config.gambit.converationsApiKey;
   }
 
@@ -20,7 +20,7 @@ class TwilioSmsInboundGambitRelayWorker extends Worker {
     const body = JSON.stringify(message.getData());
     const headers = this.getRequestHeaders(message);
     const response = await fetch(
-      `${this.baseURL}/receive-message`,
+      `${this.baseURI}/messages?origin=twilio`,
       {
         method: 'POST',
         headers,

--- a/src/workers/TwilioSmsInboundGambitRelayWorker.js
+++ b/src/workers/TwilioSmsInboundGambitRelayWorker.js
@@ -12,15 +12,15 @@ class TwilioSmsInboundGambitRelayWorker extends Worker {
       queue: this.blink.queues.twilioSmsInboundGambitRelayQ,
     });
     // Setup Gambit.
-    this.baseURI = this.blink.config.gambit.conversationsBaseUri;
-    this.apiKey = this.blink.config.gambit.conversationsApiKey;
+    this.baseURL = this.blink.config.gambit.conversations.baseURL;
+    this.apiKey = this.blink.config.gambit.conversations.apiKey;
   }
 
   async consume(message) {
     const body = JSON.stringify(message.getData());
     const headers = this.getRequestHeaders(message);
     const response = await fetch(
-      `${this.baseURI}/messages?origin=twilio`,
+      `${this.baseURL}/messages?origin=twilio`,
       {
         method: 'POST',
         headers,

--- a/src/workers/TwilioSmsInboundGambitRelayWorker.js
+++ b/src/workers/TwilioSmsInboundGambitRelayWorker.js
@@ -13,7 +13,7 @@ class TwilioSmsInboundGambitRelayWorker extends Worker {
     });
     // Setup Gambit.
     this.baseURI = this.blink.config.gambit.conversationsBaseUri;
-    this.apiKey = this.blink.config.gambit.converationsApiKey;
+    this.apiKey = this.blink.config.gambit.conversationsApiKey;
   }
 
   async consume(message) {


### PR DESCRIPTION
_Note_: This can't be deployed to production until https://github.com/DoSomething/gambit-conversations/pull/283 is merged and deployed. Ok for testing on staging, as #283 has been deployed to staging for review.

---

 Updates the `TwilioSmsInboundGambitRelayWorker` to post inbound Twilio messages to `/v2/messages` per https://github.com/DoSomething/gambit-conversations/pull/283 and some cleanup:

* Fixes `conversationsApiKey` typo.

* Removes pre-TGM  `baseUrl` and `apiKey` properties that posted to Gambit Campaigns, adds a `conversations` object to the Gambit config to group Gambit services. 

* Renames `baseUri` to `baseURL`, previous Gambit `baseURL` as `v1BaseURL`