### PR TITLE
Override validate method inside FreeFormMessage

### DIFF
--- a/src/messages/FreeFormMessage.js
+++ b/src/messages/FreeFormMessage.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 
 const Message = require('./Message');
+const MessageValidationBlinkError = require('../errors/MessageValidationBlinkError');
 
 class FreeFormMessage extends Message {
   constructor(...args) {
@@ -11,6 +12,19 @@ class FreeFormMessage extends Message {
     this.schema = Joi.object()
       // Allow presence of all other keys.
       .unknown();
+  }
+
+  validate() {
+    const { error, value } = Joi.validate(
+      this.getData(),
+      this.schema || {},
+    );
+    if (error) {
+      throw new MessageValidationBlinkError(error.message, this.toString());
+    }
+
+    this.payload.data = value;
+    return true;
   }
 }
 


### PR DESCRIPTION
## What's this PR do? 
It overrides the validation method in FreeFromMessage to allow all keys, including those that contain `null` values.

#### Context
The [latest changes](https://github.com/DoSomething/blink/pull/191) to add frictionless validation to Campaign Signup Post messages had the side effect of restricting `null` values for all Messages. The `/quasar-relay` route contract to other apps is that it should be able to consume any valid JSON data sent to it, the last changes broke that contract. This PR fixes it.

cc @DFurnes @sheyd 

## How can this be reviewed?
- 👀 

## Pending tasks
- [x] Team Storm confirms that payloads containing `null` values are being pass-through on **staging**
