### PR TITLE
Implement minimum validations in UserMessage

### DIFF
--- a/src/messages/CampaignSignupPostMessage.js
+++ b/src/messages/CampaignSignupPostMessage.js
@@ -51,6 +51,7 @@ class CampaignSignupPostMessage extends Message {
       if (key === 'id' || key === 'signup_id') return String(value);
       if (key === 'quantity') return Number(value);
       if (key === 'created_at') return moment(value).unix();
+      if (key === 'updated_at') return moment(value).unix();
       return value;
     });
 

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -66,7 +66,7 @@ class Message {
    * validate - It validates the message's schema. If the minimum set of keys defined in the schema
    * is not met, the validation fails, throwing a MessageValidationBlinkError error. By default, it
    * allows all other non null keys to pass validation. In strict mode, it strips all
-   * unknown keys -- Keys not defined explicitely in the validation schema itself.
+   * unknown keys -- Keys not defined explicitly in the validation schema itself.
    *
    * This method should be overridden in children classes if the default
    * doesn't fit the desired functionality. Example: FreeFormMessage

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -62,6 +62,17 @@ class Message {
     return JSON.stringify(this.payload);
   }
 
+  /**
+   * validate - It validates the message's schema. If the minimum set of keys defined in the schema
+   * is not met, the validation fails, throwing a MessageValidationBlinkError error. By default, it
+   * allows all other non null keys to pass validation. In strict mode, it strips all
+   * unknown keys -- Keys not defined explicitely in the validation schema itself.
+   *
+   * This method should be overridden in children classes if the default
+   * doesn't fit the desired functionality. Example: FreeFormMessage
+   *
+   * @param  {type} strict = false - Use strict mode
+   */
   validate(strict = false) {
     const options = {};
     let filtered;
@@ -81,7 +92,7 @@ class Message {
       throw new MessageValidationBlinkError(error.message, this.toString());
     }
 
-    // If unknown keys are allowed, some might include null values
+    // If unknown keys are allowed, some might include null values, remove them
     if (!strict) {
       filtered = underscore.pick(data, value => !underscore.isNull(value));
     }

--- a/src/messages/UserMessage.js
+++ b/src/messages/UserMessage.js
@@ -1,12 +1,31 @@
 'use strict';
 
+const Joi = require('joi');
+
 const Message = require('./Message');
 const schema = require('../validations/userCreateAndUpdate');
+const MessageValidationBlinkError = require('../errors/MessageValidationBlinkError');
 
 class UserMessage extends Message {
   constructor(...args) {
     super(...args);
     this.schema = schema;
+  }
+
+  validate() {
+    const { error, value } = Joi.validate(
+      this.getData(),
+      this.schema || {},
+      {
+        allowUnknown: true,
+      },
+    );
+    if (error) {
+      throw new MessageValidationBlinkError(error.message, this.toString());
+    }
+
+    this.payload.data = value;
+    return true;
   }
 }
 

--- a/src/messages/UserMessage.js
+++ b/src/messages/UserMessage.js
@@ -1,73 +1,12 @@
 'use strict';
 
-const Joi = require('joi');
-
 const Message = require('./Message');
+const schema = require('../validations/userCreateAndUpdate');
 
 class UserMessage extends Message {
   constructor(...args) {
     super(...args);
-
-    // Data validation rules.
-    // TODO: move to helpers.
-    const whenNullOrEmpty = Joi.valid(['', null]);
-    const optionalStringDefaultsToNull = Joi.string().empty(whenNullOrEmpty).default(null);
-    const optionalDateDefaultsToNull = Joi.string().isoDate().empty(whenNullOrEmpty).default(null);
-
-    this.schema = Joi.object().keys({
-      id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
-
-      // Remove field when provided as empty string or null.
-      email: Joi.string().empty(whenNullOrEmpty).default(undefined),
-      mobile: Joi.string().empty(whenNullOrEmpty).default(undefined),
-
-      // Required:
-      updated_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
-      created_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
-      sms_status: Joi.any().default(null),
-
-      // Optional, defaults to null when provided as empty string or null.
-      last_authenticated_at: optionalDateDefaultsToNull,
-      birthdate: Joi.string()
-        .empty(whenNullOrEmpty)
-        .regex(/^(\d{4})-(\d{2})-(\d{2})$/, 'valid birthdate')
-        .default(null),
-      facebook_id: optionalStringDefaultsToNull,
-      first_name: optionalStringDefaultsToNull,
-      last_name: optionalStringDefaultsToNull,
-      addr_city: optionalStringDefaultsToNull,
-      addr_state: optionalStringDefaultsToNull,
-      addr_zip: optionalStringDefaultsToNull,
-      source: optionalStringDefaultsToNull,
-      source_detail: optionalStringDefaultsToNull,
-      language: optionalStringDefaultsToNull,
-      country: optionalStringDefaultsToNull,
-
-      // Allow anything as a role, but default to user.
-      role: Joi.string().empty(whenNullOrEmpty).default('user'),
-
-      // When interests not present, make them an empty array.
-      interests: Joi.array().items(Joi.string()).empty(null).default(null),
-    })
-    // Require presence at least one of: email, mobile.
-      .or('email', 'mobile');
-  }
-
-  isMobileOnly() {
-    const userData = this.getData();
-    if (!userData.email) {
-      return true;
-    }
-    if (userData.email === '') {
-      return true;
-    }
-    if (userData.email.match(/@.*\.import$/)) {
-      return true;
-    }
-    if (userData.source === 'runscope') {
-      return true;
-    }
-    return false;
+    this.schema = schema;
   }
 }
 

--- a/src/validations/userCreateAndUpdate.js
+++ b/src/validations/userCreateAndUpdate.js
@@ -14,6 +14,8 @@ const schema = Joi.object().keys({
   email: Joi.string().empty(whenNullOrEmpty).default(undefined),
   mobile: Joi.string().empty(whenNullOrEmpty).default(undefined),
 
+  // Although this is NOT required to be sent, we make it implicitly required to exist in
+  // the payload we send to C.io by declaring a default.
   // Allow anything as a role, but default to user.
   role: Joi.string().empty(whenNullOrEmpty).default('user'),
 })

--- a/src/validations/userCreateAndUpdate.js
+++ b/src/validations/userCreateAndUpdate.js
@@ -7,8 +7,8 @@ const whenNullOrEmpty = Joi.valid(['', null]);
 // Required minimum
 const schema = Joi.object().keys({
   id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
-  updated_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
-  created_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
+  updated_at: Joi.required().empty(whenNullOrEmpty),
+  created_at: Joi.required().empty(whenNullOrEmpty),
 
   // Remove field when provided as empty string or null.
   email: Joi.string().empty(whenNullOrEmpty).default(undefined),

--- a/src/validations/userCreateAndUpdate.js
+++ b/src/validations/userCreateAndUpdate.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Joi = require('joi');
+
+const whenNullOrEmpty = Joi.valid(['', null]);
+
+// Required minimum
+const schema = Joi.object().keys({
+  id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
+  updated_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
+  created_at: Joi.string().empty(whenNullOrEmpty).required().isoDate(),
+
+  // Remove field when provided as empty string or null.
+  email: Joi.string().empty(whenNullOrEmpty).default(undefined),
+  mobile: Joi.string().empty(whenNullOrEmpty).default(undefined),
+
+  // Allow anything as a role, but default to user.
+  role: Joi.string().empty(whenNullOrEmpty).default('user'),
+})
+  // Require presence at least one of: email, mobile.
+  .or('email', 'mobile');
+
+module.exports = schema;

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -29,7 +29,7 @@ class EventsWebController extends WebController {
   async userCreate(ctx) {
     try {
       const userMessage = UserMessage.fromCtx(ctx);
-      userMessage.validateStrict();
+      userMessage.validate();
       this.blink.broker.publishToRoute(
         'create.user.event',
         userMessage,

--- a/src/workers/CustomerIoUpdateCustomerWorker.js
+++ b/src/workers/CustomerIoUpdateCustomerWorker.js
@@ -22,7 +22,6 @@ class CustomerIoUpdateCustomerWorker extends Worker {
     let customerIoUpdateCustomerMessage;
     try {
       customerIoUpdateCustomerMessage = CustomerIoUpdateCustomerMessage.fromUser(userMessage);
-      customerIoUpdateCustomerMessage.validateStrict();
     } catch (error) {
       meta = {
         env: this.blink.config.app.env,

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -58,8 +58,11 @@ class MessageFactoryHelper {
         country: chance.country(),
         drupal_id: chance.natural().toString(),
         role: chance.pickone(['user', 'admin', 'staff']),
-        // Dates are arbitrary, but it's make more sense when they are within
+        // Dates are arbitrary, but it makes more sense when they are within
         // different ranges.
+        last_messaged_at: chance.date({
+          year: chance.year({ min: 2014, max: 2015 }),
+        }).toISOString(),
         last_authenticated_at: chance.date({
           year: chance.year({ min: 2013, max: 2015 }),
         }).toISOString(),
@@ -88,6 +91,7 @@ class MessageFactoryHelper {
             null,
           ]),
           last_authenticated_at: chance.timestamp(),
+          last_messaged_at: chance.timestamp(),
           birthdate: moment(chance.birthday({ type: 'teen' })).format('YYYY-MM-DD'),
           facebook_id: chance.fbid().toString(),
           first_name: chance.first(),

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -45,6 +45,7 @@ class MessageFactoryHelper {
         slack_id: chance.natural().toString(),
         mobilecommons_id: chance.natural().toString(),
         parse_installation_ids: chance.n(chance.guid, 2),
+        sms_paused: chance.bool(),
         sms_status: chance.pickone([
           'undeliverable',
           'less',

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -78,8 +78,9 @@ class MessageFactoryHelper {
         id: fakeId,
         data: {
           email: chance.email(),
-          updated_at: chance.timestamp(),
-          created_at: chance.timestamp(),
+          updated_at: chance.pickone([moment().toISOString(), chance.timestamp()]),
+          created_at: chance.pickone([moment().toISOString(), chance.timestamp()]),
+          sms_paused: chance.bool(),
           sms_status: chance.pickone([
             'undeliverable',
             'active',
@@ -88,7 +89,7 @@ class MessageFactoryHelper {
             'stop',
             null,
           ]),
-          last_authenticated_at: chance.timestamp(),
+          last_authenticated_at: chance.pickone([moment().toISOString(), chance.timestamp()]),
           last_messaged_at: chance.timestamp(),
           birthdate: moment(chance.birthday({ type: 'teen' })).format('YYYY-MM-DD'),
           facebook_id: chance.fbid().toString(),

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -60,9 +60,7 @@ class MessageFactoryHelper {
         role: chance.pickone(['user', 'admin', 'staff']),
         // Dates are arbitrary, but it makes more sense when they are within
         // different ranges.
-        last_messaged_at: chance.date({
-          year: chance.year({ min: 2014, max: 2015 }),
-        }).toISOString(),
+        last_messaged_at: chance.timestamp(),
         last_authenticated_at: chance.date({
           year: chance.year({ min: 2013, max: 2015 }),
         }).toISOString(),

--- a/test/helpers/MessageValidationHelper.js
+++ b/test/helpers/MessageValidationHelper.js
@@ -52,25 +52,6 @@ class MessageValidationHelper {
     mutant.validateStrict();
     mutant.getData().should.not.have.property(fieldName);
   }
-
-  static defaultsToWhenEmpty(fieldName, defaultValue, generator, mutator) {
-    const mutant = mutator({
-      remove: fieldName,
-      message: generator(),
-    });
-    mutant.validateStrict();
-    mutant.getData().should.have.property(fieldName).and.be.equal(defaultValue);
-  }
-
-
-  static ensureType(fieldName, incorrectValue, generator, mutator) {
-    const mutant = mutator({
-      change: fieldName,
-      value: incorrectValue,
-      message: generator(),
-    });
-    mutant.validateStrict.should.throw(MessageValidationBlinkError, `"${fieldName}" must be a`);
-  }
 }
 
 module.exports = MessageValidationHelper;

--- a/test/unit/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/unit/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -4,45 +4,16 @@
 
 const test = require('ava');
 const chai = require('chai');
-const Chance = require('chance');
 const moment = require('moment');
 
-const MessageValidationBlinkError = require('../../../src/errors/MessageValidationBlinkError');
 const CustomerIoUpdateCustomerMessage = require('../../../src/messages/CustomerIoUpdateCustomerMessage');
 const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
-const MessageValidationHelper = require('../../helpers/MessageValidationHelper');
 
 
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const expect = chai.expect;
-const chance = new Chance();
 const generator = MessageFactoryHelper.getValidCustomerIoIdentify;
-const mutator = function ({ remove, change, value, message }) {
-  const mutant = message;
-  if (remove) {
-    let ref;
-    if (remove === 'id') {
-      ref = mutant.payload.data;
-    } else {
-      ref = mutant.payload.data.data;
-    }
-    delete ref[remove];
-    return mutant;
-  }
-  if (change) {
-    let ref;
-    if (change === 'id') {
-      ref = mutant.payload.data;
-    } else {
-      ref = mutant.payload.data.data;
-    }
-    ref[change] = value;
-    return mutant;
-  }
-  return false;
-};
 
 // ------- Tests ---------------------------------------------------------------
 
@@ -50,83 +21,16 @@ test('User message generator', () => {
   generator().should.be.an.instanceof(CustomerIoUpdateCustomerMessage);
 });
 
-test('Validate a hundred fake identify messages', () => {
-  let count = 100;
-  while (count > 0) {
-    generator().validateStrict.should.not.throw(MessageValidationBlinkError);
-    count -= 1;
-  }
-});
-
-test('Cio identify should fail if required fields are missing, undefined, null, or empty', () => {
-  [
-    'id',
-    'created_at',
-    'updated_at',
-  ]
-    .forEach(field => MessageValidationHelper.failsWithout(field, generator, mutator));
-});
-
-test('Cio identify should remove certain optional fields when empty', () => {
-  [
-    'sms_status',
-    'last_authenticated_at',
-    'birthdate',
-    'facebook_id',
-    'first_name',
-    'last_name',
-    'addr_city',
-    'addr_state',
-    'addr_zip',
-    'source',
-    'source_detail',
-    'language',
-    'country',
-    'unsubscribed',
-  ]
-    .forEach(field => MessageValidationHelper.removesWhenEmpty(field, generator, mutator));
-});
-
-test('Cio identify should fail on incorrect types', () => {
-  const mapping = {
-    id: chance.integer(),
-    email: chance.integer(),
-    updated_at: chance.date().toISOString(),
-    created_at: chance.date().toISOString(),
-    last_authenticated_at: chance.date().toISOString(),
-    birthdate: chance.timestamp(),
-    facebook_id: parseInt(chance.fbid(), 10),
-    first_name: chance.integer(),
-    last_name: chance.integer(),
-    addr_city: chance.integer(),
-    addr_state: chance.integer(),
-    addr_zip: chance.integer(),
-    source: chance.integer(),
-    source_detail: chance.integer(),
-    language: chance.integer(),
-    country: chance.integer(),
-    unsubscribed: chance.word(),
-    role: chance.integer(),
-    interests: chance.word(),
-  };
-  Object.entries(mapping).forEach(([field, incorrectValue]) => {
-    MessageValidationHelper.ensureType(field, incorrectValue, generator, mutator);
-  });
-});
-
-
 test('Cio identify created from Northstar is correct', () => {
   let count = 100;
   while (count > 0) {
     const userMessage = MessageFactoryHelper.getValidUser();
-    userMessage.validateStrict();
+    userMessage.validate();
     const userData = userMessage.getData();
     const customerIoUpdateCustomerMessage = CustomerIoUpdateCustomerMessage.fromUser(
       userMessage,
-      true,
     );
 
-    customerIoUpdateCustomerMessage.validateStrict.should.not.throw(MessageValidationBlinkError);
     const cioUpdateData = customerIoUpdateCustomerMessage.getData();
 
     // Compare properties.
@@ -145,50 +49,6 @@ test('Cio identify created from Northstar is correct', () => {
     cioUpdateAttributes.should.have.property(
       'created_at',
       moment(userData.created_at).unix(),
-    );
-
-    // Optional:
-    if (cioUpdateAttributes.sms_status) {
-      expect(cioUpdateAttributes.sms_status).to.be.equal(
-        userData.sms_status,
-      );
-    }
-    expect(cioUpdateAttributes.last_authenticated_at).to.be.equal(
-      moment(userData.last_authenticated_at).unix(),
-    );
-    expect(cioUpdateAttributes.first_name).to.be.equal(
-      userData.first_name,
-    );
-    expect(cioUpdateAttributes.last_name).to.be.equal(
-      userData.last_name,
-    );
-    expect(cioUpdateAttributes.addr_city).to.be.equal(
-      userData.addr_city,
-    );
-    expect(cioUpdateAttributes.addr_state).to.be.equal(
-      userData.addr_state,
-    );
-    expect(cioUpdateAttributes.addr_zip).to.be.equal(
-      userData.addr_zip,
-    );
-    expect(cioUpdateAttributes.source).to.be.equal(
-      userData.source,
-    );
-    expect(cioUpdateAttributes.source_detail).to.be.equal(
-      userData.source_detail,
-    );
-    expect(cioUpdateAttributes.language).to.be.equal(
-      userData.language,
-    );
-    expect(cioUpdateAttributes.country).to.be.equal(
-      userData.country,
-    );
-    expect(cioUpdateAttributes.unsubscribed).to.be.equal(false);
-    expect(cioUpdateAttributes.role).to.be.equal(
-      userData.role,
-    );
-    expect(cioUpdateAttributes.interests).to.deep.equal(
-      userData.interests,
     );
     count -= 1;
   }

--- a/test/unit/messages/UserMessage.test.js
+++ b/test/unit/messages/UserMessage.test.js
@@ -4,7 +4,6 @@
 
 const test = require('ava');
 const chai = require('chai');
-const Chance = require('chance');
 
 const MessageValidationBlinkError = require('../../../src/errors/MessageValidationBlinkError');
 const UserMessage = require('../../../src/messages/UserMessage');
@@ -14,7 +13,6 @@ const MessageValidationHelper = require('../../helpers/MessageValidationHelper')
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const chance = new Chance();
 const generator = MessageFactoryHelper.getValidUser;
 const mutator = function ({ remove, change, value, message }) {
   const mutant = message;
@@ -38,7 +36,7 @@ test('User message generator', () => {
 test('Validate a hundred fake users', () => {
   let count = 100;
   while (count > 0) {
-    generator().validateStrict.should.not.throw(MessageValidationBlinkError);
+    generator().validate.should.not.throw(MessageValidationBlinkError);
     count -= 1;
   }
 });
@@ -58,95 +56,6 @@ test('User Message should remove certain optional fields when empty', () => {
     'mobile',
   ]
     .forEach(field => MessageValidationHelper.removesWhenEmpty(field, generator, mutator));
-});
-
-test('User Message optional fields should have correct default values', () => {
-  const mapping = {
-    last_authenticated_at: null,
-    birthdate: null,
-    facebook_id: null,
-    first_name: null,
-    last_name: null,
-    addr_city: null,
-    addr_state: null,
-    addr_zip: null,
-    source: null,
-    source_detail: null,
-    language: null,
-    country: null,
-    role: 'user',
-    interests: null,
-    sms_status: null,
-  };
-  Object.entries(mapping).forEach(([field, defaultValue]) => {
-    MessageValidationHelper.defaultsToWhenEmpty(field, defaultValue, generator, mutator);
-  });
-});
-
-test('User Message should fail on incorrect types', () => {
-  const mapping = {
-    id: chance.integer(),
-    email: chance.integer(),
-    mobile: chance.integer(),
-    updated_at: chance.integer(),
-    created_at: chance.integer(),
-    // no sms_status
-    last_authenticated_at: chance.integer(),
-    birthdate: chance.integer(),
-    facebook_id: chance.integer(),
-    first_name: chance.integer(),
-    last_name: chance.integer(),
-    addr_city: chance.integer(),
-    addr_state: chance.integer(),
-    addr_zip: chance.integer(),
-    source: chance.integer(),
-    source_detail: chance.integer(),
-    language: chance.integer(),
-    country: chance.integer(),
-    role: chance.integer(),
-    interests: chance.word(),
-  };
-  Object.entries(mapping).forEach(([field, incorrectValue]) => {
-    MessageValidationHelper.ensureType(field, incorrectValue, generator, mutator);
-  });
-});
-
-test('Test mobile only users', () => {
-  let mutant;
-
-  // Test normal user.
-  generator().isMobileOnly().should.be.false;
-
-  // Test no email
-  mutant = mutator({
-    remove: 'email',
-    message: generator(),
-  });
-  mutant.isMobileOnly().should.be.true;
-
-  // Test no email
-  mutant = mutator({
-    change: 'email',
-    value: '',
-    message: generator(),
-  });
-  mutant.isMobileOnly().should.be.true;
-
-  // Test 15554443332@mobile.import
-  mutant = mutator({
-    change: 'email',
-    value: '15554443332@mobile.import',
-    message: generator(),
-  });
-  mutant.isMobileOnly().should.be.true;
-
-  // Test runscope source
-  mutant = mutator({
-    change: 'source',
-    value: 'runscope',
-    message: generator(),
-  });
-  mutant.isMobileOnly().should.be.true;
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/unit/messages/UserMessage.test.js
+++ b/test/unit/messages/UserMessage.test.js
@@ -50,12 +50,4 @@ test('User Message should fail if required fields are missing, undefined, null, 
     .forEach(field => MessageValidationHelper.failsWithout(field, generator, mutator));
 });
 
-test('User Message should remove certain optional fields when empty', () => {
-  [
-    'email',
-    'mobile',
-  ]
-    .forEach(field => MessageValidationHelper.removesWhenEmpty(field, generator, mutator));
-});
-
 // ------- End -----------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

#### Validations for the `/api/v1/events/user-create` route.

It validates only a minimum set of required properties that the messaging team is expecting for successful segmentation. All other properties sent, aside from this subset of required props, are considered optional or nullable. The Required properties are:
- id (northstar_id)
- updated_at
- created_at
- email OR mobile

## How to test
- Run the tests and get no errors:
    - `cd` into your local Blink repo.
    - `yarn install`
    - `docker-compose up -d`
    - `yarn test:full`
    - `docker-compose down`

## Relevant Issues
Fixes `last_messaged_at` bug [Pivotal #152901264](https://www.pivotaltracker.com/story/show/152901264)
Fixes `sms_paused` bug [Pivotal #153457736](https://www.pivotaltracker.com/story/show/153457736)

## Other tasks
- [x] Deploy to staging.
- [x] Going through an user creation/update and inspecting the events generated for the **staging** user in the **staging** C.io instance.
- [x] Update [UserMessage Schema](https://github.com/DoSomething/blink/wiki/Message-Schemas#usermessage) Wiki docs.