### PR TITLE
Feature/twilio sms outbound status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,7 @@ GAMBIT_API_KEY=totallysecret
 
 # Gambit Conversations
 GAMBIT_CONVERSATIONS_API_KEY=dG90YWxseXNlY3JldA==
-GAMBIT_CONVERSATIONS_API_BASEURI=http://localhost:5100/api/v2
-# v1 var to be deprecated
-GAMBIT_CONVERSATIONS_BASE_URL=http://localhost:5100/api/v1
+GAMBIT_CONVERSATIONS_API_BASE_URL=http://localhost:5100/api/v2
 
 # Customer.io
 # See https://fly.customer.io/account/customerio_integration

--- a/Procfile
+++ b/Procfile
@@ -10,3 +10,4 @@ twilio-sms-inbound-gambit-relay: npm run worker twilio-sms-inbound-gambit-relay
 redis-retries-republish: npm run timer redis-retries-republish
 twilio-sms-broadcast-gambit-relay: npm run worker twilio-sms-broadcast-gambit-relay
 twilio-sms-outbound-status-relay: npm run worker twilio-sms-outbound-status-relay
+twilio-sms-outbound-error-relay: npm run worker twilio-sms-outbound-error-relay

--- a/Procfile
+++ b/Procfile
@@ -9,3 +9,4 @@ gambit-campaign-signup-relay: npm run worker gambit-campaign-signup-relay
 twilio-sms-inbound-gambit-relay: npm run worker twilio-sms-inbound-gambit-relay
 redis-retries-republish: npm run timer redis-retries-republish
 twilio-sms-broadcast-gambit-relay: npm run worker twilio-sms-broadcast-gambit-relay
+twilio-sms-outbound-status-relay: npm run worker twilio-sms-outbound-status-relay

--- a/config/app.js
+++ b/config/app.js
@@ -11,6 +11,8 @@ const config = {
   },
   version: packageJson.version,
   retrySuppressHeader: 'x-blink-retry-suppress',
+  // http status codes that will not trigger a retry
+  allowedStatuses: [200, 204, 422],
   prefetchCount: parseInt(process.env.BLINK_APP_DEFAULT_PREFETCH_COUNT, 10) || 30,
   rateLimit: parseInt(process.env.BLINK_APP_DEFAULT_RATE_LIMIT, 10) || 100,
   // @todo: remove temporary limit

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -2,7 +2,6 @@
 
 const config = {
   conversations: {
-    // TODO: rename config variable to BASE_URL for consistency.
     baseURL: process.env.GAMBIT_CONVERSATIONS_API_BASE_URL || 'http://localhost:5100/api/v2',
     apiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
   },

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -9,4 +9,9 @@ const config = {
   broadcastSpeedLimit: process.env.GAMBIT_BROADCAST_SPEED_LIMIT || 50,
 };
 
+/**
+ * TODO: This is a hack while we fix the version and routing discrepancy in G-Conversations
+ */
+config.conversations.v1MessagesBaseURL = config.conversations.baseURL.replace(/v2/, 'v1');
+
 module.exports = config;

--- a/config/gambit.js
+++ b/config/gambit.js
@@ -3,7 +3,7 @@
 const config = {
   conversations: {
     // TODO: rename config variable to BASE_URL for consistency.
-    baseURL: process.env.GAMBIT_CONVERSATIONS_API_BASEURI || 'http://localhost:5100/api/v2',
+    baseURL: process.env.GAMBIT_CONVERSATIONS_API_BASE_URL || 'http://localhost:5100/api/v2',
     apiKey: process.env.GAMBIT_CONVERSATIONS_API_KEY || 'dG90YWxseXNlY3JldA==',
   },
   broadcastSpeedLimit: process.env.GAMBIT_BROADCAST_SPEED_LIMIT || 50,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   rabbitmq:
-    image: rabbitmq:3.6.9-management
+    image: rabbitmq:3.6.14-management
     environment:
       RABBITMQ_DEFAULT_USER: 'blink'
       RABBITMQ_DEFAULT_VHOST: 'blink'

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chance": "^1.0.12",
     "change-case": "^3.0.1",
     "customerio-node": "^0.2.0",
+    "deep-extend": "^0.5.0",
     "dotenv": "^4.0.0",
     "ioredis": "^3.2.2",
     "joi": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
     "node": "8.9.4",

--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -20,6 +20,7 @@ const CustomerIoUpdateCustomerQ = require('../queues/CustomerIoUpdateCustomerQ')
 const FetchQ = require('../queues/FetchQ');
 const GambitCampaignSignupRelayQ = require('../queues/GambitCampaignSignupRelayQ');
 const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
+// TODO: Deprecate and remove
 const TwilioSmsBroadcastGambitRelayQ = require('../queues/TwilioSmsBroadcastGambitRelayQ');
 const TwilioSmsInboundGambitRelayQ = require('../queues/TwilioSmsInboundGambitRelayQ');
 const TwilioSmsOutboundErrorRelayQ = require('../queues/TwilioSmsOutboundErrorRelayQ');

--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -22,6 +22,8 @@ const GambitCampaignSignupRelayQ = require('../queues/GambitCampaignSignupRelayQ
 const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
 const TwilioSmsBroadcastGambitRelayQ = require('../queues/TwilioSmsBroadcastGambitRelayQ');
 const TwilioSmsInboundGambitRelayQ = require('../queues/TwilioSmsInboundGambitRelayQ');
+const TwilioSmsOutboundErrorRelayQ = require('../queues/TwilioSmsOutboundErrorRelayQ');
+const TwilioSmsOutboundStatusRelayQ = require('../queues/TwilioSmsOutboundStatusRelayQ');
 
 // ------- Class ---------------------------------------------------------------
 
@@ -166,6 +168,8 @@ class BlinkApp {
       QuasarCustomerIoEmailActivityQ,
       TwilioSmsBroadcastGambitRelayQ,
       TwilioSmsInboundGambitRelayQ,
+      TwilioSmsOutboundErrorRelayQ,
+      TwilioSmsOutboundStatusRelayQ,
     ];
   }
 

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -10,6 +10,7 @@ const FetchWorker = require('../workers/FetchWorker');
 const GambitCampaignSignupRelayWorker = require('../workers/GambitCampaignSignupRelayWorker');
 const TwilioSmsBroadcastGambitRelayWorker = require('../workers/TwilioSmsBroadcastGambitRelayWorker');
 const TwilioSmsInboundGambitRelayWorker = require('../workers/TwilioSmsInboundGambitRelayWorker');
+const TwilioSmsOutboundStatusRelayWorker = require('../workers/TwilioSmsOutboundStatusRelayWorker');
 const BlinkApp = require('./BlinkApp');
 
 class BlinkWorkerApp extends BlinkApp {
@@ -50,6 +51,7 @@ class BlinkWorkerApp extends BlinkApp {
       'gambit-campaign-signup-relay': GambitCampaignSignupRelayWorker,
       'twilio-sms-broadcast-gambit-relay': TwilioSmsBroadcastGambitRelayWorker,
       'twilio-sms-inbound-gambit-relay': TwilioSmsInboundGambitRelayWorker,
+      'twilio-sms-outbound-status-relay': TwilioSmsOutboundStatusRelayWorker,
     };
   }
 }

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -11,6 +11,7 @@ const GambitCampaignSignupRelayWorker = require('../workers/GambitCampaignSignup
 const TwilioSmsBroadcastGambitRelayWorker = require('../workers/TwilioSmsBroadcastGambitRelayWorker');
 const TwilioSmsInboundGambitRelayWorker = require('../workers/TwilioSmsInboundGambitRelayWorker');
 const TwilioSmsOutboundStatusRelayWorker = require('../workers/TwilioSmsOutboundStatusRelayWorker');
+const TwilioSmsOutboundErrorRelayWorker = require('../workers/TwilioSmsOutboundErrorRelayWorker');
 const BlinkApp = require('./BlinkApp');
 
 class BlinkWorkerApp extends BlinkApp {
@@ -52,6 +53,7 @@ class BlinkWorkerApp extends BlinkApp {
       'twilio-sms-broadcast-gambit-relay': TwilioSmsBroadcastGambitRelayWorker,
       'twilio-sms-inbound-gambit-relay': TwilioSmsInboundGambitRelayWorker,
       'twilio-sms-outbound-status-relay': TwilioSmsOutboundStatusRelayWorker,
+      'twilio-sms-outbound-error-relay': TwilioSmsOutboundErrorRelayWorker,
     };
   }
 }

--- a/src/lib/helpers/gambit.js
+++ b/src/lib/helpers/gambit.js
@@ -10,6 +10,27 @@ const deepExtend = require('deep-extend');
 const gambitConfig = require('../../../config/gambit');
 
 /**
+ * getMessageIdBySidPath
+ *
+ * @param  {string} messageSid
+ * @return {string}             path
+ */
+module.exports.getMessageIdBySidPath = function getMessageIdBySidPath(messageSid) {
+  return `messages?query={"platformMessageId":"${messageSid}"}&select=id&limit=1`;
+};
+
+
+/**
+ * getUpdateMessagePath
+ *
+ * @param  {string} messageId
+ * @return {string}           path
+ */
+module.exports.getUpdateMessagePath = function getUpdateMessagePath(messageId) {
+  return `messages/${messageId}`;
+};
+
+/**
  * get - Sends a GET requests to the v1MessagesBaseURL host and given path
  *
  * @async
@@ -28,7 +49,7 @@ module.exports.executeGet = async function executeGet(path, opts = {}) {
  * update - Sends a PATCH request to the baseURL host and given path
  *
  * @async
- * @param  {String} path
+ * @param  {string} path
  * @param  {Object} opts = {}
  * @return {Promise}
  */
@@ -40,17 +61,17 @@ module.exports.executeUpdate = async function executeUpdate(path, opts = {}) {
 };
 
 /**
- * getMessageIdBySid - Gets a message from Gambit Conversations by the platformMessageId.
+ * getMessageIdBySid - Gets a message from Gambit Conversations by the messageSid.
  * The message contains an _id property when found.
  *
  * @async
- * @param  {String} platformMessageId
+ * @param  {string} messageSid
  * @param  {Object} opts
  * @return {Promise}
  */
-module.exports.getMessageIdBySid = async function getMessageIdBySid(platformMessageId, opts) {
+module.exports.getMessageIdBySid = async function getMessageIdBySid(messageSid, opts) {
   // @see https://www.npmjs.com/package/express-restify-mongoose
-  const path = `messages?query={"platformMessageId":"${platformMessageId}"}&select=id&limit=1`;
+  const path = exports.getMessageIdBySidPath(messageSid);
   return exports.executeGet(path, opts);
 };
 
@@ -63,7 +84,7 @@ module.exports.getMessageIdBySid = async function getMessageIdBySid(platformMess
  * @return {Promise}
  */
 module.exports.updateMessage = async function updateMessage(messageId, opts) {
-  const path = `messages/${messageId}`;
+  const path = exports.getUpdateMessagePath(messageId);
   return exports.executeUpdate(path, opts);
 };
 
@@ -102,21 +123,19 @@ module.exports.getFailedAtUpdateBody = function getFailedAtUpdateBody(message) {
 };
 
 /**
- * parseMessageIdFromResponse - Given a node-fetch response. It parses the _id out of the response
- * body we get from G-Conversations v1/messages route.
+ * parseMessageIdFromBody - It parses the _id out of the given response body
+ * from the G-Conversations v1/messages request.
  *
  *
  * WARNING: This method is coupled with G-Conversations implementation of the v1/messages route.
  * G-Conversations uses express-restify-mongoose, which sends the found tuples in an array.
  *
- * @async
- * @param  {type} response description
- * @return {type}          description
+ * @param  {array} body description
+ * @return {string}
  */
-module.exports.parseMessageIdFromResponse = async function parseMessageIdFromResponse(response) {
-  const body = await response.json();
+module.exports.parseMessageIdFromBody = function parseMessageIdFromBody(body) {
   if (!Array.isArray(body) || body.length <= 0) {
-    throw new Error('parseMessageIdFromResponse(): Non empty array expected in response');
+    throw new Error('parseMessageIdFromBody(): Non empty array expected in response');
   }
   return body[0]._id; // eslint-disable-line no-underscore-dangle
 };

--- a/src/lib/helpers/gambit.js
+++ b/src/lib/helpers/gambit.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const fetch = require('node-fetch');
+/**
+ * Deep Extend is used because Object.assign does shallow-copy only. Nested objects are
+ * referenced instead of copied which can bring unintended consequences.
+ */
+const deepExtend = require('deep-extend');
+
+const gambitConfig = require('../../../config/gambit');
+
+/**
+ * get - Sends a GET requests to the v1MessagesBaseURL host and given path
+ *
+ * @async
+ * @param  {String} path
+ * @param  {Object} opts = {}
+ * @return {Promise}
+ */
+module.exports.executeGet = async function executeGet(path, opts = {}) {
+  const options = Object.assign({}, deepExtend(opts, {
+    method: 'GET',
+  }));
+  return fetch(`${gambitConfig.conversations.v1MessagesBaseURL}/${path}`, options);
+};
+
+/**
+ * update - Sends a PATCH request to the baseURL host and given path
+ *
+ * @async
+ * @param  {String} path
+ * @param  {Object} opts = {}
+ * @return {Promise}
+ */
+module.exports.executeUpdate = async function executeUpdate(path, opts = {}) {
+  const options = Object.assign({}, deepExtend(opts, {
+    method: 'PATCH',
+  }));
+  return fetch(`${gambitConfig.conversations.baseURL}/${path}`, options);
+};
+
+/**
+ * getMessageIdBySid - Gets a message from Gambit Conversations by the platformMessageId.
+ * The message contains an _id property when found.
+ *
+ * @async
+ * @param  {String} platformMessageId
+ * @param  {Object} opts
+ * @return {Promise}
+ */
+module.exports.getMessageIdBySid = async function getMessageIdBySid(platformMessageId, opts) {
+  // @see https://www.npmjs.com/package/express-restify-mongoose
+  const path = `messages?query={"platformMessageId":"${platformMessageId}"}&select=id&limit=1`;
+  return exports.executeGet(path, opts);
+};
+
+/**
+ * updateMessage - Updates a message in Gambit Conversations by the messageId.
+ *
+ * @async
+ * @param  {String} messageId
+ * @param  {Object} opts
+ * @return {Promise}
+ */
+module.exports.updateMessage = async function updateMessage(messageId, opts) {
+  const path = `messages/${messageId}`;
+  return exports.executeUpdate(path, opts);
+};
+
+/**
+ * getDeliveredAtUpdateBody
+ *
+ * @return {Object}  The metadata update to be sent to G-Conversations
+ */
+module.exports.getDeliveredAtUpdateBody = function getDeliveredAtUpdateBody(message) {
+  return {
+    metadata: {
+      delivery: {
+        deliveredAt: message.deliveredAt,
+      },
+    },
+  };
+};
+
+/**
+ * getFailedAtUpdateBody
+ *
+ * @return {Object}  The metadata update to be sent to G-Conversations
+ */
+module.exports.getFailedAtUpdateBody = function getFailedAtUpdateBody(message) {
+  return {
+    metadata: {
+      delivery: {
+        failedAt: message.failedAt,
+        failureData: {
+          code: message.ErrorCode,
+          message: message.ErrorMessage,
+        },
+      },
+    },
+  };
+};
+
+/**
+ * parseMessageIdFromResponse - Given a node-fetch response. It parses the _id out of the response
+ * body we get from G-Conversations v1/messages route.
+ *
+ *
+ * WARNING: This method is coupled with G-Conversations implementation of the v1/messages route.
+ * G-Conversations uses express-restify-mongoose, which sends the found tuples in an array.
+ *
+ * @async
+ * @param  {type} response description
+ * @return {type}          description
+ */
+module.exports.parseMessageIdFromResponse = async function parseMessageIdFromResponse(response) {
+  const body = await response.json();
+  if (!Array.isArray(body) || body.length <= 0) {
+    throw new Error('parseMessageIdFromResponse(): Non empty array expected in response');
+  }
+  return body[0]._id; // eslint-disable-line no-underscore-dangle
+};

--- a/src/lib/helpers/worker.js
+++ b/src/lib/helpers/worker.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const blinkAppConfig = require('../../../config/app');
+
+/**
+ * checkRetrySuppress - Looks for the suppress headers in the node-fetch response
+ *
+ * @param  {Object} response node-fetch response
+ * @return {boolean}
+ */
+module.exports.checkRetrySuppress = function checkRetrySuppress(response) {
+  const headerResult = response.headers.get(blinkAppConfig.retrySuppressHeader);
+  if (!headerResult) {
+    return false;
+  }
+  return headerResult.toLowerCase() === 'true';
+};
+
+
+/**
+ * isAllowedHttpStatus
+ *
+ * @param  {number} statusCode
+ * @return {boolean}
+ */
+module.exports.isAllowedHttpStatus = function isAllowedHttpStatus(statusCode) {
+  return blinkAppConfig.allowedStatuses.includes(statusCode);
+};
+
+/**
+ * shouldRetry - The request should not retry if the status code is one of the allowed codes, or
+ * if G-Conversations returned the suppress retry header
+ *
+ * @param  {Object} response node-fetch response
+ * @return {boolean}
+ */
+module.exports.shouldRetry = function shouldRetry(response) {
+  const allowedStatus = exports.isAllowedHttpStatus(response.status);
+  const suppressed = exports.checkRetrySuppress(response);
+
+  if (suppressed || allowedStatus) {
+    return false;
+  }
+  return true;
+};

--- a/src/messages/TwilioOutboundStatusCallbackMessage.js
+++ b/src/messages/TwilioOutboundStatusCallbackMessage.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const FreeFormMessage = require('./FreeFormMessage');
+
+class TwilioOutboundStatusCallbackMessage extends FreeFormMessage {
+  isError() {
+    return !!this.getData().ErrorCode;
+  }
+  isDelivered() {
+    return this.getData().Status === 'delivered';
+  }
+}
+
+module.exports = TwilioOutboundStatusCallbackMessage;

--- a/src/messages/TwilioOutboundStatusCallbackMessage.js
+++ b/src/messages/TwilioOutboundStatusCallbackMessage.js
@@ -9,6 +9,12 @@ class TwilioOutboundStatusCallbackMessage extends FreeFormMessage {
   isDelivered() {
     return this.getData().MessageStatus === 'delivered';
   }
+  setDeliveredAt(date) {
+    this.payload.data.deliveredAt = date;
+  }
+  setFailedAt(date) {
+    this.payload.data.failedAt = date;
+  }
 }
 
 module.exports = TwilioOutboundStatusCallbackMessage;

--- a/src/messages/TwilioOutboundStatusCallbackMessage.js
+++ b/src/messages/TwilioOutboundStatusCallbackMessage.js
@@ -7,7 +7,7 @@ class TwilioOutboundStatusCallbackMessage extends FreeFormMessage {
     return !!this.getData().ErrorCode;
   }
   isDelivered() {
-    return this.getData().Status === 'delivered';
+    return this.getData().MessageStatus === 'delivered';
   }
 }
 

--- a/src/messages/TwilioStatusCallbackMessage.js
+++ b/src/messages/TwilioStatusCallbackMessage.js
@@ -4,6 +4,10 @@ const Joi = require('joi');
 
 const Message = require('./Message');
 
+/**
+ * DEPRECATED
+ * TODO: Remove this message class
+ */
 class TwilioStatusCallbackMessage extends Message {
   constructor(...args) {
     super(...args);

--- a/src/queues/TwilioSmsOutboundErrorRelayQ.js
+++ b/src/queues/TwilioSmsOutboundErrorRelayQ.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const TwilioOutboundStatusCallbackMessage = require('../messages/TwilioOutboundStatusCallbackMessage');
+const Queue = require('../lib/Queue');
+
+class TwilioSmsOutboundErrorRelayQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.messageClass = TwilioOutboundStatusCallbackMessage;
+    this.routes.push('sms-outbound-error.twilio.webhook');
+  }
+}
+
+module.exports = TwilioSmsOutboundErrorRelayQ;

--- a/src/queues/TwilioSmsOutboundStatusRelayQ.js
+++ b/src/queues/TwilioSmsOutboundStatusRelayQ.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const TwilioOutboundStatusCallbackMessage = require('../messages/TwilioOutboundStatusCallbackMessage');
+const Queue = require('../lib/Queue');
+
+class TwilioSmsOutboundStatusRelayQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.messageClass = TwilioOutboundStatusCallbackMessage;
+    this.routes.push('sms-outbound-status.twilio.webhook');
+  }
+}
+
+module.exports = TwilioSmsOutboundStatusRelayQ;

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const moment = require('moment');
+
 const CustomerioGambitBroadcastMessage = require('../../messages/CustomerioGambitBroadcastMessage');
 const CustomerIoWebhookMessage = require('../../messages/CustomerIoWebhookMessage');
 const FreeFormMessage = require('../../messages/FreeFormMessage');
@@ -89,11 +91,17 @@ class WebHooksWebController extends WebController {
       message.validate();
 
       if (message.isError()) {
+        message.setFailedAt(moment().format());
         this.blink.broker.publishToRoute(
           'sms-outbound-error.twilio.webhook',
           message,
         );
       } else if (message.isDelivered()) {
+        /**
+         * We don't get this info in the status callback payload from Twilio so we have to
+         * set ourselves
+         */
+        message.setDeliveredAt(moment().format());
         this.blink.broker.publishToRoute(
           'sms-outbound-status.twilio.webhook',
           message,

--- a/src/web/middleware/auth/strategies/twilioSignature.js
+++ b/src/web/middleware/auth/strategies/twilioSignature.js
@@ -16,7 +16,7 @@ function twilioSignature(twilioConfig) {
   return function (ctx, next) {
     const signature = ctx.get('x-twilio-signature');
     // @see https://nodejs.org/api/url.html#url_the_whatwg_url_api
-    const urlObj = ctx.request.URL;
+    // const urlObj = ctx.request.URL;
 
     /**
      * While developing and using ngrok to tunnel requests from a real mobile to Blink's localhost.
@@ -26,7 +26,8 @@ function twilioSignature(twilioConfig) {
      *
      * Alternatively. TEMPORARILY, manually hardcode the correct URL here.
      */
-    const url = `${urlObj.protocol}//${urlObj.hostname}${urlObj.pathname}`;
+    // const url = `${urlObj.protocol}//${urlObj.hostname}${urlObj.pathname}`;
+    const url = 'https://682ccc4d.ngrok.io/api/v1/webhooks/twilio-sms-outbound-status';
     const payload = ctx.request.body;
     const valid = twilioClient.validateRequest(authToken, signature, url, payload);
 

--- a/src/web/middleware/auth/strategies/twilioSignature.js
+++ b/src/web/middleware/auth/strategies/twilioSignature.js
@@ -27,7 +27,6 @@ function twilioSignature(twilioConfig) {
      * Alternatively. TEMPORARILY, manually hardcode the correct URL here.
      */
     const url = `${urlObj.protocol}//${urlObj.hostname}${urlObj.pathname}`;
-    // const url = 'https://682ccc4d.ngrok.io/api/v1/webhooks/twilio-sms-outbound-status';
     const payload = ctx.request.body;
     const valid = twilioClient.validateRequest(authToken, signature, url, payload);
 

--- a/src/web/middleware/auth/strategies/twilioSignature.js
+++ b/src/web/middleware/auth/strategies/twilioSignature.js
@@ -16,7 +16,7 @@ function twilioSignature(twilioConfig) {
   return function (ctx, next) {
     const signature = ctx.get('x-twilio-signature');
     // @see https://nodejs.org/api/url.html#url_the_whatwg_url_api
-    // const urlObj = ctx.request.URL;
+    const urlObj = ctx.request.URL;
 
     /**
      * While developing and using ngrok to tunnel requests from a real mobile to Blink's localhost.
@@ -26,8 +26,8 @@ function twilioSignature(twilioConfig) {
      *
      * Alternatively. TEMPORARILY, manually hardcode the correct URL here.
      */
-    // const url = `${urlObj.protocol}//${urlObj.hostname}${urlObj.pathname}`;
-    const url = 'https://682ccc4d.ngrok.io/api/v1/webhooks/twilio-sms-outbound-status';
+    const url = `${urlObj.protocol}//${urlObj.hostname}${urlObj.pathname}`;
+    // const url = 'https://682ccc4d.ngrok.io/api/v1/webhooks/twilio-sms-outbound-status';
     const payload = ctx.request.body;
     const valid = twilioClient.validateRequest(authToken, signature, url, payload);
 

--- a/src/web/middleware/auth/strategies/twilioSignature.js
+++ b/src/web/middleware/auth/strategies/twilioSignature.js
@@ -5,7 +5,6 @@ const logger = require('winston');
 
 const ForbiddenBlinkError = require('../../../../errors/ForbiddenBlinkError');
 
-
 /**
  * twilioSignature - middleware that authenticates requests from Twilio.
  * @see https://www.twilio.com/docs/api/security#validating-requests

--- a/src/workers/GambitConversationsRelayWorker.js
+++ b/src/workers/GambitConversationsRelayWorker.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const logger = require('winston');
+
+const BlinkRetryError = require('../errors/BlinkRetryError');
+const Worker = require('./Worker');
+
+/**
+ * Represents a GambitConversationsRelay type of worker.
+ * Workers that intend to relay messages to G-Conversations should inherit from this Worker.
+ */
+class GambitConversationsRelayWorker extends Worker {
+  setup({ queue }) {
+    super.setup({ queue });
+    this.logCodes = {
+      retry: 'error_gambit_conversations_response_not_200_retry',
+      success: 'success_gambit_conversations_response_200',
+      suppress: 'success_gambit_conversations_retry_suppress',
+      unprocessable: 'error_gambit_conversations_response_422',
+    };
+    // Setup Gambit Conversations
+    this.apiKey = this.blink.config.gambit.conversations.apiKey;
+    this.allowedStatuses = [200, 204, 422];
+  }
+
+  /**
+   * handleResponse - Takes in a node-fetch response and determines if the request should be
+   * retried, or logged.
+   *
+   * @param  {Object} message
+   * @param  {Object} response node-fetch response
+   * @return {boolean}
+   */
+  handleResponse(message, response) {
+    if (this.shouldRetry(response)) {
+      return this.logAndRetry(message, response);
+    }
+    return this.logResponse(message, response);
+  }
+
+  /**
+   * logResponse
+   *
+   * @param  {Object} message
+   * @param  {Object} response node-fetch response
+   * @return {boolean}
+   */
+  logResponse(message, response) {
+    if (response.status === 200 || response.status === 204) {
+      return this.logSuccess(message, response);
+    } else if (this.checkRetrySuppress(response)) {
+      return this.logSuppressedRetry(message, response);
+    } else if (response.status === 422) {
+      return this.logUnprocessableEntity(message, response);
+    }
+    return true;
+  }
+
+  /**
+   * shouldRetry - The request should not retry if the status code is one of the allowed codes, or
+   * if G-Conversations returned the suppress retry header
+   *
+   * @param  {Object} response node-fetch response
+   * @return {boolean}
+   */
+  shouldRetry(response) {
+    const allowedStatus = this.allowedStatuses.includes(response.status);
+    const suppressed = this.checkRetrySuppress(response);
+
+    if (suppressed || allowedStatus) {
+      return false;
+    }
+    return true;
+  }
+
+  logAndRetry(message, response) {
+    this.log(
+      'warning',
+      message,
+      response,
+      this.logCodes.retry,
+    );
+
+    throw new BlinkRetryError(
+      `${response.status} ${response.statusText}`,
+      message,
+    );
+  }
+
+  /**
+   * logSuccess
+   *
+   * @param  {Object} message
+   * @param  {Object} response node-fetch response
+   * @return {boolean}
+   */
+  logSuccess(message, response) {
+    this.log(
+      'debug',
+      message,
+      response,
+      this.logCodes.success,
+    );
+    return true;
+  }
+
+  /**
+   * logSuppressedRetry
+   *
+   * @param  {Object} message
+   * @param  {Object} response node-fetch response
+   * @return {boolean}
+   */
+  logSuppressedRetry(message, response) {
+    this.log(
+      'debug',
+      message,
+      response,
+      this.logCodes.suppress,
+    );
+    return true;
+  }
+
+  /**
+   * logUnprocessableEntity
+   *
+   * @param  {Object} message
+   * @param  {Object} response node-fetch response
+   * @return {boolean}
+   */
+  logUnprocessableEntity(message, response) {
+    this.log(
+      'warning',
+      message,
+      response,
+      this.logCodes.unprocessable,
+    );
+    return false;
+  }
+
+  /**
+   * async log - description
+   *
+   * @async
+   * @param  {string} level                    log level
+   * @param  {Object} message
+   * @param  {Object} response                 node-fetch response
+   * @param  {string} code = 'unexpected_code'
+   */
+  async log(level, message, response, code = 'unexpected_code') {
+    const meta = {
+      env: this.blink.config.app.env,
+      code,
+      worker: this.constructor.name,
+      request_id: message ? message.getRequestId() : 'not_parsed',
+      response_status: response.status,
+      response_status_text: `"${response.statusText}"`,
+    };
+    // Todo: log error?
+    logger.log(level, '', meta);
+  }
+
+  /**
+   * getRequestHeaders - Get G-Conversations specific headers for this message
+   *
+   * @param  {Object} message
+   * @return {Object}
+   */
+  getRequestHeaders(message) {
+    const headers = {
+      Authorization: `Basic ${this.apiKey}`,
+      'X-Request-ID': message.getRequestId(),
+      'Content-type': 'application/json',
+    };
+
+    if (message.getRetryAttempt() > 0) {
+      headers['x-blink-retry-count'] = message.getRetryAttempt();
+    }
+
+    return headers;
+  }
+
+  /**
+   * checkRetrySuppress - Looks for the suppress headers in the node-fetch response
+   *
+   * @param  {Object} response node-fetch response
+   * @return {boolean}
+   */
+  checkRetrySuppress(response) {
+    // TODO: create common helper
+    const headerResult = response.headers.get(this.blink.config.app.retrySuppressHeader);
+    if (!headerResult) {
+      return false;
+    }
+    return headerResult.toLowerCase() === 'true';
+  }
+}
+
+module.exports = GambitConversationsRelayWorker;

--- a/src/workers/TwilioSmsOutboundErrorRelayWorker.js
+++ b/src/workers/TwilioSmsOutboundErrorRelayWorker.js
@@ -3,28 +3,28 @@
 const GambitConversationsRelayWorker = require('./GambitConversationsRelayWorker');
 const gambitHelper = require('../lib/helpers/gambit');
 
-class TwilioSmsOutboundStatusRelayWorker extends GambitConversationsRelayWorker {
+class TwilioSmsOutboundErrorRelayWorker extends GambitConversationsRelayWorker {
   setup() {
     super.setup({
-      queue: this.blink.queues.twilioSmsOutboundStatusRelayQ,
+      queue: this.blink.queues.twilioSmsOutboundErrorRelayQ,
     });
     this.logCodes = {
-      retry: 'error_gambit_outbound_status_relay_response_not_200_retry',
-      success: 'success_gambit_outbound_status_relay_response_200',
-      suppress: 'success_gambit_outbound_status_relay_retry_suppress',
-      unprocessable: 'error_gambit_outbound_status_relay_response_422',
+      retry: 'error_gambit_outbound_error_relay_response_not_200_retry',
+      success: 'success_gambit_outbound_error_relay_response_200',
+      suppress: 'success_gambit_outbound_error_relay_retry_suppress',
+      unprocessable: 'error_gambit_outbound_error_relay_response_422',
     };
   }
 
   async consume(message) {
     const messageId = await this.getMessageIdToUpdate(message);
-    const body = JSON.stringify(gambitHelper.getDeliveredAtUpdateBody(message.getData()));
+    const body = JSON.stringify(gambitHelper.getFailedAtUpdateBody(message.getData()));
     const headers = this.getRequestHeaders(message);
     const response = await gambitHelper.updateMessage(messageId, {
       headers,
       body,
     });
-    return this.handleResponse(message, response);
+    this.handleResponse(message, response);
   }
 
   async getMessageIdToUpdate(message) {
@@ -38,4 +38,4 @@ class TwilioSmsOutboundStatusRelayWorker extends GambitConversationsRelayWorker 
   }
 }
 
-module.exports = TwilioSmsOutboundStatusRelayWorker;
+module.exports = TwilioSmsOutboundErrorRelayWorker;

--- a/src/workers/TwilioSmsOutboundErrorRelayWorker.js
+++ b/src/workers/TwilioSmsOutboundErrorRelayWorker.js
@@ -24,7 +24,7 @@ class TwilioSmsOutboundErrorRelayWorker extends GambitConversationsRelayWorker {
       headers,
       body,
     });
-    this.handleResponse(message, response);
+    return this.handleResponse(message, response);
   }
 
   async getMessageIdToUpdate(message) {
@@ -34,7 +34,7 @@ class TwilioSmsOutboundErrorRelayWorker extends GambitConversationsRelayWorker {
       headers,
     });
     this.handleResponse(message, response);
-    return gambitHelper.parseMessageIdFromResponse(response);
+    return gambitHelper.parseMessageIdFromBody(await response.json());
   }
 }
 

--- a/src/workers/TwilioSmsOutboundStatusRelayWorker.js
+++ b/src/workers/TwilioSmsOutboundStatusRelayWorker.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const fetch = require('node-fetch');
+const logger = require('winston');
+
+const BlinkRetryError = require('../errors/BlinkRetryError');
+const Worker = require('./Worker');
+
+class TwilioSmsOutboundStatusRelayWorker extends Worker {
+  setup() {
+    super.setup({
+      queue: this.blink.queues.twilioSmsOutboundStatusRelayQ,
+    });
+    // Setup Gambit.
+    this.baseURL = this.blink.config.gambit.conversations.baseURL;
+    this.v1MessagesBaseURL = this.blink.config.gambit.conversations.baseURL.replace(/v2/, 'v1');
+    this.apiKey = this.blink.config.gambit.conversations.apiKey;
+  }
+
+  async consume(message) {
+    const messageId = await this.getMessageIdToUpdate(message);
+    const body = JSON.stringify(message.getData());
+    const headers = this.getRequestHeaders(message);
+    const response = await fetch(
+      `${this.baseURL}/messages/${messageId}`,
+      {
+        method: 'PATCH',
+        headers,
+        body,
+      },
+    );
+    this.processResponse(response, message);
+  }
+
+  async getMessageIdToUpdate(message) {
+    const messageSid = message.getData().MessageSid;
+    const headers = this.getRequestHeaders(message);
+    const response = await fetch(
+      `${this.v1MessagesBaseURL}/messages?query={"platformMessageId":"${messageSid}"}&select=id`,
+      {
+        method: 'GET',
+        headers,
+      },
+    );
+
+    this.processResponse(response, message);
+
+    const data = response.body;
+    return data._id; // eslint-disable-line no-underscore-dangle
+  }
+
+  processResponse(response, message) {
+    if (response.status === 200) {
+      return this.logSuccess(message, response);
+    }
+
+    if (this.checkRetrySuppress(response)) {
+      return this.logSuppressedRetry(message, response);
+    }
+
+    if (response.status === 422) {
+      return this.logUnprocessableEntity(message, response);
+    }
+
+    return this.retry(message, response);
+  }
+
+  retry(message, response) {
+    this.log(
+      'warning',
+      message,
+      response,
+      'error_gambit_inbound_relay_response_not_200_retry',
+    );
+
+    throw new BlinkRetryError(
+      `${response.status} ${response.statusText}`,
+      message,
+    );
+  }
+
+  logSuccess(message, response) {
+    this.log(
+      'debug',
+      message,
+      response,
+      'success_gambit_inbound_relay_response_200',
+    );
+    return true;
+  }
+
+  logSuppressedRetry(message, response) {
+    this.log(
+      'debug',
+      message,
+      response,
+      'success_gambit_inbound_relay_retry_suppress',
+    );
+    return true;
+  }
+
+  logUnprocessableEntity(message, response) {
+    this.log(
+      'warning',
+      message,
+      response,
+      'error_gambit_inbound_relay_response_422',
+    );
+    return false;
+  }
+
+  async log(level, message, response, code = 'unexpected_code') {
+    const cleanedBody = (await response.text()).replace(/\n/g, '\\n');
+
+    const meta = {
+      env: this.blink.config.app.env,
+      code,
+      worker: this.constructor.name,
+      request_id: message ? message.getRequestId() : 'not_parsed',
+      response_status: response.status,
+      response_status_text: `"${response.statusText}"`,
+    };
+    // Todo: log error?
+    logger.log(level, cleanedBody, meta);
+  }
+
+  getRequestHeaders(message) {
+    const headers = {
+      Authorization: `Basic ${this.apiKey}`,
+      'X-Request-ID': message.getRequestId(),
+      'Content-type': 'application/json',
+    };
+
+    if (message.getRetryAttempt() > 0) {
+      headers['x-blink-retry-count'] = message.getRetryAttempt();
+    }
+
+    return headers;
+  }
+
+  checkRetrySuppress(response) {
+    // TODO: create common helper
+    const headerResult = response.headers.get(this.blink.config.app.retrySuppressHeader);
+    if (!headerResult) {
+      return false;
+    }
+    return headerResult.toLowerCase() === 'true';
+  }
+}
+
+module.exports = TwilioSmsOutboundStatusRelayWorker;

--- a/src/workers/TwilioSmsOutboundStatusRelayWorker.js
+++ b/src/workers/TwilioSmsOutboundStatusRelayWorker.js
@@ -34,7 +34,7 @@ class TwilioSmsOutboundStatusRelayWorker extends GambitConversationsRelayWorker 
       headers,
     });
     this.handleResponse(message, response);
-    return gambitHelper.parseMessageIdFromResponse(response);
+    return gambitHelper.parseMessageIdFromBody(await response.json());
   }
 }
 

--- a/src/workers/TwilioSmsOutboundStatusRelayWorker.js
+++ b/src/workers/TwilioSmsOutboundStatusRelayWorker.js
@@ -17,24 +17,23 @@ class TwilioSmsOutboundStatusRelayWorker extends GambitConversationsRelayWorker 
   }
 
   async consume(message) {
-    const messageId = await this.getMessageIdToUpdate(message);
+    let messageId;
+    const getMessageResponse = await gambitHelper.getMessageToUpdate(message);
+    this.handleResponse(message, getMessageResponse);
+
+    try {
+      messageId = gambitHelper.parseMessageIdFromBody(await getMessageResponse.json());
+    } catch (error) {
+      return this.logAndRetry(message, 500, error.message);
+    }
+
     const body = JSON.stringify(gambitHelper.getDeliveredAtUpdateBody(message.getData()));
-    const headers = this.getRequestHeaders(message);
-    const response = await gambitHelper.updateMessage(messageId, {
+    const headers = gambitHelper.getRequestHeaders(message);
+    const updateResponse = await gambitHelper.updateMessage(messageId, {
       headers,
       body,
     });
-    return this.handleResponse(message, response);
-  }
-
-  async getMessageIdToUpdate(message) {
-    const messageSid = message.getData().MessageSid;
-    const headers = this.getRequestHeaders(message);
-    const response = await gambitHelper.getMessageIdBySid(messageSid, {
-      headers,
-    });
-    this.handleResponse(message, response);
-    return gambitHelper.parseMessageIdFromBody(await response.json());
+    return this.handleResponse(message, updateResponse);
   }
 }
 

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -143,9 +143,9 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidOutboundDeliveredStatusData() {
+  static getValidTwilioOutboundStatusData(deliveredAt) {
     const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
-    return new TwilioOutboundStatusCallbackMessage({
+    const msg = new TwilioOutboundStatusCallbackMessage({
       data: {
         SmsSid: sid,
         SmsStatus: 'delivered',
@@ -155,15 +155,18 @@ class MessageFactoryHelper {
         AccountSid: sid,
         From: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
         ApiVersion: '2010-04-01',
-        deliveredAt: chance.date({ year: (new Date()).getFullYear() }).toISOString(),
       },
       meta: {},
     });
+    if (deliveredAt) {
+      msg.setDeliveredAt(deliveredAt);
+    }
+    return msg;
   }
 
-  static getValidOutboundErrorStatusData() {
+  static getValidTwilioOutboundErrorStatusData(failedAt) {
     const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
-    return new TwilioOutboundStatusCallbackMessage({
+    const msg = new TwilioOutboundStatusCallbackMessage({
       data: {
         SmsSid: sid,
         SmsStatus: 'delivered',
@@ -173,12 +176,15 @@ class MessageFactoryHelper {
         AccountSid: sid,
         From: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
         ApiVersion: '2010-04-01',
-        failedAt: chance.date({ year: (new Date()).getFullYear() }).toISOString(),
         ErrorCode: 30006,
         ErrorMessage: 'Landline or unreachable carrier',
       },
       meta: {},
     });
+    if (failedAt) {
+      msg.setFailedAt(failedAt);
+    }
+    return msg;
   }
 
   static getValidMessageData() {

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -11,6 +11,7 @@ const CampaignSignupPostReviewMessage = require('../../src/messages/CampaignSign
 const CustomerIoUpdateCustomerMessage = require('../../src/messages/CustomerIoUpdateCustomerMessage');
 const FreeFormMessage = require('../../src/messages/FreeFormMessage');
 const TwilioStatusCallbackMessage = require('../../src/messages/TwilioStatusCallbackMessage');
+const TwilioOutboundStatusCallbackMessage = require('../../src/messages/TwilioOutboundStatusCallbackMessage');
 const UserMessage = require('../../src/messages/UserMessage');
 
 // ------- Init ----------------------------------------------------------------
@@ -142,9 +143,49 @@ class MessageFactoryHelper {
     });
   }
 
+  static getValidOutboundDeliveredStatusData() {
+    const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
+    return new TwilioOutboundStatusCallbackMessage({
+      data: {
+        SmsSid: sid,
+        SmsStatus: 'delivered',
+        MessageStatus: 'delivered',
+        To: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
+        MessageSid: sid,
+        AccountSid: sid,
+        From: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
+        ApiVersion: '2010-04-01',
+        deliveredAt: chance.date({ year: (new Date()).getFullYear() }).toISOString(),
+      },
+      meta: {},
+    });
+  }
+
+  static getValidOutboundErrorStatusData() {
+    const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
+    return new TwilioOutboundStatusCallbackMessage({
+      data: {
+        SmsSid: sid,
+        SmsStatus: 'delivered',
+        MessageStatus: 'delivered',
+        To: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
+        MessageSid: sid,
+        AccountSid: sid,
+        From: `+1555${chance.string({ length: 7, pool: '1234567890' })}`,
+        ApiVersion: '2010-04-01',
+        failedAt: chance.date({ year: (new Date()).getFullYear() }).toISOString(),
+        ErrorCode: 30006,
+        ErrorMessage: 'Landline or unreachable carrier',
+      },
+      meta: {},
+    });
+  }
+
   static getValidMessageData() {
     // TODO: randomize
     const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
+    // TODO: This is not a StatusCallbackMessage payload, but an actual message resource payload
+    // This message is deprecated. Remove this.
     return new TwilioStatusCallbackMessage({
       data: {
         ToCountry: 'US',

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -170,7 +170,7 @@ test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming paylo
 });
 
 /**
- * POST /api/v1/webhooks/customerio-gambit-broadcast
+ * POST /api/v1/webhooks/twilio-sms-outbound-status
  */
 test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-status-relay when a valid x-twilio-signature is received', async (t) => {
   const message = MessageFactoryHelper.getValidOutboundDeliveredStatusData();
@@ -215,7 +215,7 @@ test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twili
 
 
 /**
- * POST /api/v1/webhooks/customerio-gambit-broadcast
+ * POST /api/v1/webhooks/twilio-sms-outbound-status
  */
 test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-error-relay when a valid x-twilio-signature is received', async (t) => {
   const message = MessageFactoryHelper.getValidOutboundErrorStatusData();

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -48,6 +48,9 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
 
   res.body.should.have.property('customerio-gambit-broadcast')
     .and.have.string('/api/v1/webhooks/customerio-gambit-broadcast');
+
+  res.body.should.have.property('twilio-sms-outbound-status')
+    .and.have.string('/api/v1/webhooks/twilio-sms-outbound-status');
 });
 
 /**
@@ -164,6 +167,95 @@ test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming paylo
   res.body.should.have.property('ok', false);
   res.body.should.have.property('message')
     .and.have.string('"northstarId" is required');
+});
+
+/**
+ * POST /api/v1/webhooks/customerio-gambit-broadcast
+ */
+test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-status-relay when a valid x-twilio-signature is received', async (t) => {
+  const message = MessageFactoryHelper.getValidOutboundDeliveredStatusData();
+  const data = message.getData();
+
+  const serverAddress = t.context.blink.web.server.address();
+  const readableUrl = `http://${serverAddress.address}`;
+  const path = '/api/v1/webhooks/twilio-sms-outbound-status';
+
+  const twilioSignature = twilioHelper.getTwilioSignature(
+    t.context.config.twilio.authToken,
+    `${readableUrl}${path}`,
+    data);
+
+  const res = await t.context.supertest.post(path)
+    .set('x-twilio-signature', twilioSignature)
+    .send(data);
+
+  // Ensure TwiML compatible response.
+  res.status.should.be.equal(204);
+  res.res.statusMessage.toLowerCase().should.equal('no content');
+
+  // Check that the message is queued.
+  const rabbit = new RabbitManagement(t.context.config.amqpManagement);
+  const messages = await rabbit.getMessagesFrom('twilio-sms-outbound-status-relay', 1, false);
+  messages.should.be.an('array').and.to.have.lengthOf(1);
+
+  messages[0].should.have.property('payload');
+  const payload = messages[0].payload;
+  const messageData = JSON.parse(payload);
+  messageData.should.have.property('data');
+
+  /**
+   * This is funky, but because deliveredAt is a property we inject based on the current timestamp
+   * just before enqueuing the message. It would change from the one we sent in this test. IRL the
+   * payload we would get from Twilio would not have a deliveredAt property and would only have it
+   * after we injected it, before being enqueued.
+   */
+  messageData.data.deliveredAt = data.deliveredAt;
+  messageData.data.should.be.eql(data);
+});
+
+
+/**
+ * POST /api/v1/webhooks/customerio-gambit-broadcast
+ */
+test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-error-relay when a valid x-twilio-signature is received', async (t) => {
+  const message = MessageFactoryHelper.getValidOutboundErrorStatusData();
+  const data = message.getData();
+
+  const serverAddress = t.context.blink.web.server.address();
+  const readableUrl = `http://${serverAddress.address}`;
+  const path = '/api/v1/webhooks/twilio-sms-outbound-status';
+
+  const twilioSignature = twilioHelper.getTwilioSignature(
+    t.context.config.twilio.authToken,
+    `${readableUrl}${path}`,
+    data);
+
+  const res = await t.context.supertest.post(path)
+    .set('x-twilio-signature', twilioSignature)
+    .send(data);
+
+  // Ensure TwiML compatible response.
+  res.status.should.be.equal(204);
+  res.res.statusMessage.toLowerCase().should.equal('no content');
+
+  // Check that the message is queued.
+  const rabbit = new RabbitManagement(t.context.config.amqpManagement);
+  const messages = await rabbit.getMessagesFrom('twilio-sms-outbound-error-relay', 1, false);
+  messages.should.be.an('array').and.to.have.lengthOf(1);
+
+  messages[0].should.have.property('payload');
+  const payload = messages[0].payload;
+  const messageData = JSON.parse(payload);
+  messageData.should.have.property('data');
+
+  /**
+   * This is funky, but because failedAt is a property we inject based on the current timestamp
+   * just before enqueuing the message. It would change from the one we sent in this test. IRL the
+   * payload we would get from Twilio would not have a failedAt property and would only have it
+   * after we injected it, before being enqueued.
+   */
+  messageData.data.failedAt = data.failedAt;
+  messageData.data.should.be.eql(data);
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -173,7 +173,7 @@ test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming paylo
  * POST /api/v1/webhooks/twilio-sms-outbound-status
  */
 test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-status-relay when a valid x-twilio-signature is received', async (t) => {
-  const message = MessageFactoryHelper.getValidOutboundDeliveredStatusData();
+  const message = MessageFactoryHelper.getValidTwilioOutboundStatusData();
   const data = message.getData();
 
   const serverAddress = t.context.blink.web.server.address();
@@ -204,12 +204,11 @@ test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twili
   messageData.should.have.property('data');
 
   /**
-   * This is funky, but because deliveredAt is a property we inject based on the current timestamp
-   * just before enqueuing the message. It would change from the one we sent in this test. IRL the
-   * payload we would get from Twilio would not have a deliveredAt property and would only have it
-   * after we injected it, before being enqueued.
+   * This is funky because deliveredAt is a property we inject based on the current timestamp
+   * just before enqueuing the message. IRL the payload we get from Twilio would not have a
+   * deliveredAt property and would only have it after we injected it, before being enqueued.
    */
-  messageData.data.deliveredAt = data.deliveredAt;
+  delete messageData.data.deliveredAt;
   messageData.data.should.be.eql(data);
 });
 
@@ -218,7 +217,7 @@ test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twili
  * POST /api/v1/webhooks/twilio-sms-outbound-status
  */
 test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-error-relay when a valid x-twilio-signature is received', async (t) => {
-  const message = MessageFactoryHelper.getValidOutboundErrorStatusData();
+  const message = MessageFactoryHelper.getValidTwilioOutboundErrorStatusData();
   const data = message.getData();
 
   const serverAddress = t.context.blink.web.server.address();
@@ -249,12 +248,11 @@ test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twili
   messageData.should.have.property('data');
 
   /**
-   * This is funky, but because failedAt is a property we inject based on the current timestamp
-   * just before enqueuing the message. It would change from the one we sent in this test. IRL the
-   * payload we would get from Twilio would not have a failedAt property and would only have it
-   * after we injected it, before being enqueued.
+   * This is funky because failedAt is a property we inject based on the current timestamp
+   * just before enqueuing the message. IRL the payload we get from Twilio would not have a
+   * failedAt property and would only have it after we injected it, before being enqueued.
    */
-  messageData.data.failedAt = data.failedAt;
+  delete messageData.data.failedAt;
   messageData.data.should.be.eql(data);
 });
 

--- a/test/unit/lib/lib-helpers/gambit.test.js
+++ b/test/unit/lib/lib-helpers/gambit.test.js
@@ -16,7 +16,7 @@ const messageFactoryHelper = require('../../../helpers/MessageFactoryHelper');
 
 // ------- Init ----------------------------------------------------------------
 
-chai.should();
+const should = chai.should();
 chai.use(sinonChai);
 const sandbox = sinon.sandbox.create();
 
@@ -65,9 +65,9 @@ test('gambitHelper: getDeliveredAtUpdateBody should return a valid payload', () 
  * updateMessage
  */
 
-test('gambitHelper: updateMessage should call executeUpdate', async () => {
+test.serial('gambitHelper: updateMessage should call executeUpdate', async () => {
   sandbox.stub(gambitHelper, 'executeUpdate')
-    .returns(Promise.resolve());
+    .returns(Promise.resolve(true));
   const messageId = 'abc123';
   const path = gambitHelper.getUpdateMessagePath(messageId);
   const opts = { whats: 'up' };
@@ -77,18 +77,46 @@ test('gambitHelper: updateMessage should call executeUpdate', async () => {
 });
 
 /**
+ * getMessageToUpdate
+ */
+
+test.serial('gambitHelper: getMessageToUpdate should call getMessageIdBySid', async () => {
+  sandbox.stub(gambitHelper, 'getMessageIdBySid')
+    .returns(Promise.resolve(true));
+  const message = messageFactoryHelper.getValidTwilioOutboundStatusData(moment().format());
+  const messageSid = message.getData().MessageSid;
+  const headers = gambitHelper.getRequestHeaders(message);
+
+  await gambitHelper.getMessageToUpdate(message);
+  gambitHelper.getMessageIdBySid.should.have.been.calledWith(messageSid, { headers });
+});
+
+/**
  * getMessageIdBySid
  */
 
-test('gambitHelper: getMessageIdBySid should call executeGet', async () => {
+test.serial('gambitHelper: getMessageIdBySid should call executeGet', async () => {
   sandbox.stub(gambitHelper, 'executeGet')
-    .returns(Promise.resolve());
+    .returns(Promise.resolve(true));
   const platformMessageId = 'abc123';
   const path = gambitHelper.getMessageIdBySidPath(platformMessageId);
   const opts = { whats: 'up' };
 
   await gambitHelper.getMessageIdBySid(platformMessageId, opts);
   gambitHelper.executeGet.should.have.been.calledWith(path, opts);
+});
+
+/**
+ * getRequestHeaders
+ */
+
+test('gambitHelper: getRequestHeaders should return valid headers', () => {
+  const message = messageFactoryHelper.getValidTwilioOutboundStatusData(moment().format());
+
+  const headers = gambitHelper.getRequestHeaders(message);
+  should.exist(headers.Authorization);
+  should.exist(headers['X-Request-ID']);
+  should.exist(headers['Content-type']);
 });
 
 // ------- End -----------------------------------------------------------------

--- a/test/unit/lib/lib-helpers/gambit.test.js
+++ b/test/unit/lib/lib-helpers/gambit.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const Promise = require('bluebird');
+
+// ------- Internal imports ----------------------------------------------------
+
+const gambitHelper = require('../../../../src/lib/helpers/gambit');
+const messageFactoryHelper = require('../../../helpers/MessageFactoryHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+chai.use(sinonChai);
+const sandbox = sinon.sandbox.create();
+
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+// ------- Tests ---------------------------------------------------------------
+
+/**
+ * parseMessageIdFromBody
+ */
+
+test('gambitHelper: parseMessageIdFromBody should throw when body is not an array', () => {
+  gambitHelper.parseMessageIdFromBody.should.throw();
+});
+
+test('gambitHelper: parseMessageIdFromBody should not throw when body is a non empty array', () => {
+  gambitHelper.parseMessageIdFromBody([{ _id: 'abc' }]).should.be.eql('abc');
+});
+
+/**
+ * getFailedAtUpdateBody
+ */
+
+test('gambitHelper: getFailedAtUpdateBody should return a valid payload', () => {
+  const message = messageFactoryHelper.getValidOutboundErrorStatusData();
+  const payload = gambitHelper.getFailedAtUpdateBody(message.getData());
+  payload.metadata.delivery.failedAt.should.exist;
+  payload.metadata.delivery.failureData.code.exist;
+  payload.metadata.delivery.failureData.message.exist;
+});
+
+/**
+ * getDeliveredAtUpdateBody
+ */
+
+test('gambitHelper: getDeliveredAtUpdateBody should return a valid payload', () => {
+  const message = messageFactoryHelper.getValidOutboundDeliveredStatusData();
+  const payload = gambitHelper.getDeliveredAtUpdateBody(message.getData());
+  payload.metadata.delivery.deliveredAt.should.exist;
+});
+
+/**
+ * updateMessage
+ */
+
+test('gambitHelper: updateMessage should call executeUpdate', async () => {
+  sandbox.stub(gambitHelper, 'executeUpdate')
+    .returns(Promise.resolve());
+  const messageId = 'abc123';
+  const path = gambitHelper.getUpdateMessagePath(messageId);
+  const opts = { whats: 'up' };
+
+  await gambitHelper.updateMessage(messageId, opts);
+  gambitHelper.executeUpdate.should.have.been.calledWith(path, opts);
+});
+
+/**
+ * getMessageIdBySid
+ */
+
+test('gambitHelper: getMessageIdBySid should call executeGet', async () => {
+  sandbox.stub(gambitHelper, 'executeGet')
+    .returns(Promise.resolve());
+  const platformMessageId = 'abc123';
+  const path = gambitHelper.getMessageIdBySidPath(platformMessageId);
+  const opts = { whats: 'up' };
+
+  await gambitHelper.getMessageIdBySid(platformMessageId, opts);
+  gambitHelper.executeGet.should.have.been.calledWith(path, opts);
+});
+
+// ------- End -----------------------------------------------------------------

--- a/test/unit/lib/lib-helpers/gambit.test.js
+++ b/test/unit/lib/lib-helpers/gambit.test.js
@@ -7,6 +7,7 @@ const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const Promise = require('bluebird');
+const moment = require('moment');
 
 // ------- Internal imports ----------------------------------------------------
 
@@ -43,7 +44,7 @@ test('gambitHelper: parseMessageIdFromBody should not throw when body is a non e
  */
 
 test('gambitHelper: getFailedAtUpdateBody should return a valid payload', () => {
-  const message = messageFactoryHelper.getValidOutboundErrorStatusData();
+  const message = messageFactoryHelper.getValidTwilioOutboundErrorStatusData(moment().format());
   const payload = gambitHelper.getFailedAtUpdateBody(message.getData());
   payload.metadata.delivery.failedAt.should.exist;
   payload.metadata.delivery.failureData.code.exist;
@@ -55,7 +56,7 @@ test('gambitHelper: getFailedAtUpdateBody should return a valid payload', () => 
  */
 
 test('gambitHelper: getDeliveredAtUpdateBody should return a valid payload', () => {
-  const message = messageFactoryHelper.getValidOutboundDeliveredStatusData();
+  const message = messageFactoryHelper.getValidTwilioOutboundStatusData(moment().format());
   const payload = gambitHelper.getDeliveredAtUpdateBody(message.getData());
   payload.metadata.delivery.deliveredAt.should.exist;
 });

--- a/test/unit/lib/lib-helpers/worker.test.js
+++ b/test/unit/lib/lib-helpers/worker.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+// ------- Internal imports ----------------------------------------------------
+
+const workerHelper = require('../../../../src/lib/helpers/worker');
+const blinkAppConfig = require('../../../../config/app');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+chai.use(sinonChai);
+const sandbox = sinon.sandbox.create();
+
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+// ------- Tests ---------------------------------------------------------------
+
+/**
+ * isAllowedHttpStatus
+ */
+
+test('workerHelper: isAllowedHttpStatus should return true for allowed status codes', () => {
+  blinkAppConfig.allowedStatuses.forEach((statusCode) => {
+    statusCode.should.be.a('number');
+    workerHelper.isAllowedHttpStatus(statusCode).should.be.true;
+  });
+});
+
+// ------- End -----------------------------------------------------------------

--- a/test/unit/messages/TwilioOutboundStatusCallbackMessage.test.js
+++ b/test/unit/messages/TwilioOutboundStatusCallbackMessage.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+const moment = require('moment');
+
+const TwilioOutboundStatusCallbackMessage = require('../../../src/messages/TwilioOutboundStatusCallbackMessage');
+const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+const should = chai.should();
+const generator = MessageFactoryHelper.getValidTwilioOutboundStatusData;
+
+// ------- Tests ---------------------------------------------------------------
+
+test('Twilio outbound status callback message generator', () => {
+  generator().should.be.an.instanceof(TwilioOutboundStatusCallbackMessage);
+});
+
+test('Twilio outbound status callback message should respond to isError, isDelivered, setDeliveredAt, and setFailedAt', () => {
+  const msg = generator();
+  msg.should.respondsTo('isError');
+  msg.should.respondsTo('isDelivered');
+  msg.should.respondsTo('setDeliveredAt');
+  msg.should.respondsTo('setFailedAt');
+});
+
+test('Twilio outbound status callback message should set deliveredAt', () => {
+  const msg = generator();
+  should.not.exist(msg.getData().deliveredAt);
+
+  msg.setDeliveredAt(moment().format());
+  should.exist(msg.getData().deliveredAt);
+});
+
+test('Twilio outbound status callback message should set failedAt', () => {
+  const msg = MessageFactoryHelper.getValidTwilioOutboundErrorStatusData();
+  should.not.exist(msg.getData().failedAt);
+
+  msg.setFailedAt(moment().format());
+  should.exist(msg.getData().failedAt);
+});
+
+// ------- End -----------------------------------------------------------------

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,6 @@
 box: node:8.9.4
 services:
-  - id: rabbitmq:3.6.9-management
+  - id: rabbitmq:3.6.14-management
     env:
       RABBITMQ_DEFAULT_USER: $BLINK_AMQP_USER
       RABBITMQ_DEFAULT_PASS: $BLINK_AMQP_PASSWORD

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,6 +1325,10 @@ deep-equal@^1.0.0, deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
+deep-extend@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.0.tgz#6ef4a09b05f98b0e358d6d93d4ca3caec6672803"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"


### PR DESCRIPTION
# What's this PR do?
- It creates one web endpoint to receive Twilio status callback requests: `/api/v1/webhooks/twilio-sms-outbound-status`.
- It adds two more queues: 
    - `twilio-sms-outbound-error-relay`
    - `twilio-sms-outbound-status-relay`
- It adds two more workers:
    - `TwilioSmsOutboundErrorRelayWorker`
    - `TwilioSmsOutboundStatusRelayWorker`
- It relays the status change to G-Conversations in order to record time of delivery or time of failure and reason.

NOTE: Missing testing integration and coverage. I'll add and update in a later commit.

## How to test
- Run unit and integration [tests](https://github.com/dosomething/blink#tests) locally.

## Relevant Issues
[Spec discussion](https://github.com/orgs/DoSomething/teams/team-odoyle/discussions/5)
Fixes [piv#152900964](https://www.pivotaltracker.com/story/show/152900964)

## Tasks
- [x] Deploy to staging.
- [x] Double check new env variables are up to date.
- [x] Update Wiki.
- [x] Add unit tests.
- [x] Add Integration test.