### PR TITLE
remove email or mobile validation in user-create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
     "node": "8.9.4",

--- a/src/validations/userCreateAndUpdate.js
+++ b/src/validations/userCreateAndUpdate.js
@@ -10,16 +10,10 @@ const schema = Joi.object().keys({
   updated_at: Joi.required().empty(whenNullOrEmpty),
   created_at: Joi.required().empty(whenNullOrEmpty),
 
-  // Remove field when provided as empty string or null.
-  email: Joi.string().empty(whenNullOrEmpty).default(undefined),
-  mobile: Joi.string().empty(whenNullOrEmpty).default(undefined),
-
   // Although this is NOT required to be sent, we make it implicitly required to exist in
   // the payload we send to C.io by declaring a default.
   // Allow anything as a role, but default to user.
   role: Joi.string().empty(whenNullOrEmpty).default('user'),
-})
-  // Require presence at least one of: email, mobile.
-  .or('email', 'mobile');
+});
 
 module.exports = schema;


### PR DESCRIPTION
## What's this PR do
Removes validation on existence of `email` or `mobile` on user create/update events. Unblocks GDPR script.