### PR TITLE
Enforces HTTPS in production

### DIFF
--- a/config/app.js
+++ b/config/app.js
@@ -15,8 +15,10 @@ const config = {
   allowedStatuses: [200, 204, 422],
   prefetchCount: parseInt(process.env.BLINK_APP_DEFAULT_PREFETCH_COUNT, 10) || 30,
   rateLimit: parseInt(process.env.BLINK_APP_DEFAULT_RATE_LIMIT, 10) || 100,
-  // @todo: remove temporary limit
+  // TODO: remove temporary limit
   retryLimit: parseInt(process.env.BLINK_APP_DEFAULT_RETRY_LIMIT, 10) || 100,
+  // overridden in production to true
+  forceHttps: false,
 };
 
 module.exports = config;

--- a/config/env/override-production.js
+++ b/config/env/override-production.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Test environment overrides.
+ *
+ * Ignoring no-param-reassign eslint rule because it's exactly what we want here.
+ */
+
+/* eslint-disable no-param-reassign */
+
+module.exports = (config) => {
+  config.app.forceHttps = true;
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "koa-basic-auth": "^3.0.0",
     "koa-bodyparser": "^4.2.0",
     "koa-router": "^7.4.0",
+    "koa-sslify": "^2.1.2",
     "moment": "^2.19.4",
     "newrelic": "^4.1.5",
     "node-fetch": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-ava": "^4.5.1",
     "nyc": "^12.0.2",
+    "rewire": "^4.0.1",
     "sinon": "^6.0.0",
     "sinon-chai": "^3.2.0",
     "supertest": "^3.1.0"

--- a/src/app/BlinkWebApp.js
+++ b/src/app/BlinkWebApp.js
@@ -15,6 +15,7 @@ const WebHooksWebController = require('../web/controllers/WebHooksWebController'
 const unauthorized401Handler = require('../web/middleware/errorHandlers/401');
 const forbidden403Handler = require('../web/middleware/errorHandlers/403');
 const generateRequestId = require('../web/middleware/generateRequestId');
+const enforceHttpsMiddleware = require('../web/middleware/enforce-https');
 const BlinkApp = require('./BlinkApp');
 
 class BlinkWebApp extends BlinkApp {
@@ -93,6 +94,10 @@ class BlinkWebApp extends BlinkApp {
     app.proxy = this.config.web.proxy;
 
     // -------- Setup web middleware --------
+
+    // Enforce https
+    app.use(enforceHttpsMiddleware(this.config.app.forceHttps));
+
     // Generate unique request id.
     app.use(generateRequestId);
 

--- a/src/web/middleware/enforce-https.js
+++ b/src/web/middleware/enforce-https.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const enforceHttps = require('koa-sslify');
+const logger = require('winston');
+
+const enforceHttpsMiddleware = function (forceHttps) {
+  logger.info(`Enforcing HTTPS connections=${forceHttps}`);
+  if (!forceHttps) {
+    return async (ctx, next) => next();
+  }
+  return enforceHttps({
+    /**
+     * Required for Heroku deployed apps
+     * @see https://www.npmjs.com/package/koa-sslify#with-reverse-proxy
+     */
+    trustProtoHeader: true,
+  });
+};
+
+module.exports = enforceHttpsMiddleware;

--- a/start.js
+++ b/start.js
@@ -4,8 +4,7 @@
 // Load enviroment vars.
 require('dotenv').config();
 
-// New Relic. ALMOST first line.
-// TODO: check if it actually breaks anything.
+// New Relic.
 require('newrelic');
 
 // ------- Imports -------------------------------------------------------------

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -21,5 +21,15 @@ module.exports = {
         message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
     ],
+    // Allow for rewire to work properly
+    'no-underscore-dangle': [
+      'error',
+      {
+        allow: [
+          '__set__',
+          '__get__'
+        ],
+      }
+    ]
   },
 };

--- a/test/unit/web/middleware/enforce-https.test.js
+++ b/test/unit/web/middleware/enforce-https.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const enforce = require('koa-sslify');
+const sinonChai = require('sinon-chai');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const enforceHttpsMiddleware = rewire('../../../../src/web/middleware/enforce-https');
+
+const sandbox = sinon.sandbox.create();
+
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+  enforceHttpsMiddleware.__set__('enforceHttps', enforce);
+});
+
+test.serial('enforceHttpsMiddleware should return dummy function that always calls next if forceHttps is false', () => {
+  const forceHttps = false;
+  const middleware = enforceHttpsMiddleware(forceHttps);
+  const next = sinon.stub();
+  const context = {};
+
+  middleware(context, next);
+  next.should.have.been.called;
+});
+
+test.serial('enforceHttpsMiddleware should return a function that enforces HTTPS if forceHttps is true', () => {
+  const forceHttps = true;
+  const enforceStub = sinon.stub();
+  enforceHttpsMiddleware.__set__('enforceHttps', enforceStub);
+  enforceHttpsMiddleware(forceHttps);
+
+  enforceStub.should.have.been.calledWith({ trustProtoHeader: true });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4516,6 +4516,12 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
+rewire@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/rewire/-/rewire-4.0.1.tgz#ba1100d400a9da759fe599fc6e0233f0879ed6da"
+  dependencies:
+    eslint "^4.19.1"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3205,6 +3205,10 @@ koa-router@^7.4.0:
     path-to-regexp "^1.1.1"
     urijs "^1.19.0"
 
+koa-sslify@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/koa-sslify/-/koa-sslify-2.1.2.tgz#8947fd53949d69d539607814097863c1ecf38f30"
+
 koa@^2.5.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/koa/-/koa-2.5.2.tgz#f2bda7f3e70be54924e7e5e9789a249f77256fe3"


### PR DESCRIPTION
#### What's this PR do?
It adds a middleware that will redirect any GET and HEAD requests to `https://`. Other requests like POSTs will return a `403`. Only while in the **production** environment. Local development will not be impacted.

NOTES:
There is a chance that this update will break other apps that are sending requests to Blink not using the HTTPS protocol. I have to check if it's just a matter of updating the ENV variable in those services first!

#### How should this be reviewed?
- 👀 
- Run all tests

#### Relevant tickets
Blink's item in [Pivotal#159114978](https://www.pivotaltracker.com/story/show/159114978)

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
