### PR TITLE
Accept `unsubscribed` when creating new user in NS

### DIFF
--- a/config/env/override-staging.js
+++ b/config/env/override-staging.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Test environment overrides.
+ *
+ * Ignoring no-param-reassign eslint rule because it's exactly what we want here.
+ */
+
+/* eslint-disable no-param-reassign */
+
+module.exports = (config) => {
+  config.app.forceHttps = true;
+};

--- a/src/messages/CustomerIoUpdateCustomerMessage.js
+++ b/src/messages/CustomerIoUpdateCustomerMessage.js
@@ -47,9 +47,8 @@ class CustomerIoUpdateCustomerMessage extends Message {
       }
     });
 
-    const isNew = customerData.created_at === customerData.updated_at;
-
     if (typeof customerData.unsubscribed === 'undefined') {
+      const isNew = customerData.created_at === customerData.updated_at;
       /**
        * If a user is newly created (created_at & updated_at are the same)
        * and unsubscribed is not included in the payload, then set them as "subscribed"

--- a/src/messages/CustomerIoUpdateCustomerMessage.js
+++ b/src/messages/CustomerIoUpdateCustomerMessage.js
@@ -47,17 +47,17 @@ class CustomerIoUpdateCustomerMessage extends Message {
       }
     });
 
-    /**
-     * TODO: Blink shouldn't have to figure out if the user is unsubscribed or not.
-     * This should come from the source, in this case Northstar.
-     * @see https://github.com/DoSomething/northstar/pull/706
-     *
-     * If a user is newly created (created_at & updated_at are the same)
-     * then set them as "subscribed" to emails in Customer.io!
-     */
     const isNew = customerData.created_at === customerData.updated_at;
-    if (customerData.email && isNew) {
-      customerData.unsubscribed = false;
+
+    if (typeof customerData.unsubscribed === 'undefined') {
+      /**
+       * If a user is newly created (created_at & updated_at are the same)
+       * and unsubscribed is not included in the payload, then set them as "subscribed"
+       * to emails in Customer.io!
+       */
+      if (customerData.email && isNew) {
+        customerData.unsubscribed = false;
+      }
     }
 
     const customerIoUpdateCustomerMessage = new CustomerIoUpdateCustomerMessage({

--- a/test/unit/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/unit/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -40,6 +40,49 @@ test('Cio identify created from Northstar is correct', () => {
     cioUpdateData.should.have.property('data').and.to.be.an('object');
     cioUpdateData.data.should.have.property('email', userData.email);
     cioUpdateData.data.should.have.property('phone', userData.mobile);
+    /**
+     * The valid user factory sets updatedAt and createdAt to the same date, hence automatically
+     * making the user subscribed
+     * NOTE: If the payload includes an "unsubscribed" property, that takes precedence.
+     */
+    cioUpdateData.data.should.have.property('unsubscribed', false);
+
+    const cioUpdateAttributes = cioUpdateData.data;
+    cioUpdateAttributes.should.have.property(
+      'updated_at',
+      moment(userData.updated_at).unix(),
+    );
+    cioUpdateAttributes.should.have.property(
+      'created_at',
+      moment(userData.created_at).unix(),
+    );
+    count -= 1;
+  }
+});
+
+test('Cio identify created from Northstar is correct when unsubscribed is set', () => {
+  let count = 100;
+  while (count > 0) {
+    const shouldSetUnsubscribed = count % 2 === 0;
+    const userMessage = MessageFactoryHelper.getValidUser();
+    userMessage.validate();
+    // Set unsubscribed
+    userMessage.payload.data.unsubscribed = shouldSetUnsubscribed;
+    const userData = userMessage.getData();
+    const customerIoUpdateCustomerMessage = CustomerIoUpdateCustomerMessage.fromUser(
+      userMessage,
+    );
+
+    const cioUpdateData = customerIoUpdateCustomerMessage.getData();
+
+    // Compare properties.
+
+    // Required:
+    cioUpdateData.should.have.property('id', userData.id);
+    cioUpdateData.should.have.property('data').and.to.be.an('object');
+    cioUpdateData.data.should.have.property('email', userData.email);
+    cioUpdateData.data.should.have.property('phone', userData.mobile);
+    cioUpdateData.data.should.have.property('unsubscribed', userData.unsubscribed);
 
     const cioUpdateAttributes = cioUpdateData.data;
     cioUpdateAttributes.should.have.property(


### PR DESCRIPTION
## What's this PR do?
- Passes along the `unsubscribed` value if it exist in the payload to `/user-create` events route.

## How to test?
- 👀 
- Run all tests

## To do
- [x] add tests