### PR TITLE
Feature/email subscription - Queue and routing

### DIFF
--- a/config/messages/CustomerIoWebhookMessage.js
+++ b/config/messages/CustomerIoWebhookMessage.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const config = {};
+
+
+/**
+ * Keys should match event names in C.io.
+ *
+ * @see https://customer.io/docs/developer-documentation/webhooks.html#events
+ *
+ * WARNING: In the worst case scenario that C.io changes an event
+ * name without letting us know, this would be the place to fix routing issues.
+ */
+config.events = {
+  /**
+   * This is a catch all "generic" events that we will fallback to if we don't have a specific
+   * C.io event config here.
+   */
+  generic: {
+    routingKey: '*.event.quasar',
+  },
+  email_unsubscribed: {
+    routingKey: 'email-unsubscribed.event.quasar',
+  },
+};
+
+module.exports = config;

--- a/config/messages/CustomerIoWebhookMessage.js
+++ b/config/messages/CustomerIoWebhookMessage.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const config = {};
-
-
 /**
  * Keys should match event names in C.io.
  *

--- a/config/messages/CustomerIoWebhookMessage.js
+++ b/config/messages/CustomerIoWebhookMessage.js
@@ -11,8 +11,8 @@ const config = {};
  */
 config.events = {
   /**
-   * This is a catch all "generic" events that we will fallback to if we don't have a specific
-   * C.io event config here.
+   * This is the catch all "generic" event that we will fallback to if we don't have a defined
+   * C.io event config for it here.
    */
   generic: {
     routingKey: '*.event.quasar',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink",
-  "version": "2.3.4",
+  "version": "2.4.1",
   "description": "The DoSomething.org Message Bus.",
   "engines": {
     "node": "8.11.3",

--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -21,6 +21,7 @@ const CustomerIoSmsStatusActiveQ = require('../queues/CustomerIoSmsStatusActiveQ
 const FetchQ = require('../queues/FetchQ');
 const GambitCampaignSignupRelayQ = require('../queues/GambitCampaignSignupRelayQ');
 const QuasarCustomerIoEmailActivityQ = require('../queues/QuasarCustomerIoEmailActivityQ');
+const QuasarCustomerIoEmailUnsubscribedQ = require('../queues/QuasarCustomerIoEmailUnsubscribedQ');
 const TwilioSmsInboundGambitRelayQ = require('../queues/TwilioSmsInboundGambitRelayQ');
 const TwilioSmsOutboundErrorRelayQ = require('../queues/TwilioSmsOutboundErrorRelayQ');
 const TwilioSmsOutboundStatusRelayQ = require('../queues/TwilioSmsOutboundStatusRelayQ');
@@ -167,6 +168,7 @@ class BlinkApp {
       FetchQ,
       GambitCampaignSignupRelayQ,
       QuasarCustomerIoEmailActivityQ,
+      QuasarCustomerIoEmailUnsubscribedQ,
       TwilioSmsInboundGambitRelayQ,
       TwilioSmsOutboundErrorRelayQ,
       TwilioSmsOutboundStatusRelayQ,

--- a/src/messages/CustomerIoWebhookMessage.js
+++ b/src/messages/CustomerIoWebhookMessage.js
@@ -3,9 +3,8 @@
 const Joi = require('joi');
 
 const Message = require('./Message');
+const config = require('../../config/messages/CustomerIoWebhookMessage');
 
-// TODO: url whitelist
-// TODO: authentication
 class CustomerIoWebhookMessage extends Message {
   constructor(...args) {
     super(...args);
@@ -17,6 +16,15 @@ class CustomerIoWebhookMessage extends Message {
       event_type: Joi.string().required(),
       timestamp: Joi.number().integer().required(),
     });
+  }
+
+  getEventType() {
+    return this.getData().event_type;
+  }
+
+  getEventRoutingKey(eventType = this.getEventType()) {
+    const eventConfig = config.events[eventType] || config.events.generic;
+    return eventConfig.routingKey;
   }
 }
 

--- a/src/queues/QuasarCustomerIoEmailActivityQ.js
+++ b/src/queues/QuasarCustomerIoEmailActivityQ.js
@@ -5,7 +5,7 @@ const Queue = require('../lib/Queue');
 class QuasarCustomerIoEmailActivityQ extends Queue {
   constructor(...args) {
     super(...args);
-    this.routes.push('generic-event.quasar');
+    this.routes.push('*.event.quasar');
   }
 }
 

--- a/src/queues/QuasarCustomerIoEmailUnsubscribedQ.js
+++ b/src/queues/QuasarCustomerIoEmailUnsubscribedQ.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Queue = require('../lib/Queue');
+
+class QuasarCustomerIoEmailUnsubscribedQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.routes.push('email-unsubscribed.event.quasar');
+  }
+}
+
+module.exports = QuasarCustomerIoEmailUnsubscribedQ;

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -122,7 +122,7 @@ class EventsWebController extends WebController {
       const message = FreeFormMessage.fromCtx(ctx);
       message.validate();
       this.blink.broker.publishToRoute(
-        'generic-event.quasar',
+        '*.event.quasar',
         message,
       );
       this.sendOK(ctx, message);

--- a/src/web/controllers/WebHooksWebController.js
+++ b/src/web/controllers/WebHooksWebController.js
@@ -65,8 +65,10 @@ class WebHooksWebController extends WebController {
     try {
       const customerIoWebhookMessage = CustomerIoWebhookMessage.fromCtx(ctx);
       customerIoWebhookMessage.validate();
-      const { quasarCustomerIoEmailActivityQ } = this.blink.queues;
-      quasarCustomerIoEmailActivityQ.publish(customerIoWebhookMessage);
+      this.blink.broker.publishToRoute(
+        customerIoWebhookMessage.getEventRoutingKey(),
+        customerIoWebhookMessage,
+      );
       this.sendOK(ctx, customerIoWebhookMessage);
     } catch (error) {
       this.sendError(ctx, error);

--- a/test/unit/queues/QuasarCustomerIoEmailActivityQ.test.js
+++ b/test/unit/queues/QuasarCustomerIoEmailActivityQ.test.js
@@ -22,7 +22,7 @@ test('QuasarCustomerIoEmailActivityQ', () => {
   const queue = new QuasarCustomerIoEmailActivityQ(new Broker());
   queue.should.be.an.instanceof(Queue);
   queue.routes.should.include('quasar-customer-io-email-activity');
-  queue.routes.should.include('generic-event.quasar');
+  queue.routes.should.include('*.event.quasar');
 });
 
 // ------- End -----------------------------------------------------------------


### PR DESCRIPTION
## What's this PR do?

It makes some changes to queue bindings so that C.io email activity requests continue to be routed to the `QuasarCustomerIoEmailActivity` queue via the `*.event.quasar` routing key. At the same time, adding the ability to copy the `email_unsubscribed` events to the `QuasarCustomerIoEmailUnsubscribed` queue via the `email-unsubscribed.event.quasar` routing key.

## How to test?
- 👀 
- Pass all tests

## To do
- [x] Add tests
