### PR TITLE
Fixes PII being removed before enqueueing messages

### DIFF
--- a/src/lib/Dequeuer.js
+++ b/src/lib/Dequeuer.js
@@ -6,6 +6,7 @@ const BlinkRetryError = require('../errors/BlinkRetryError');
 const logger = require('../../config/logger');
 const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 const MessageValidationBlinkError = require('../errors/MessageValidationBlinkError');
+const removePIITransformer = require('./helpers/logger/transformers/remove-pii');
 
 class Dequeuer {
   constructor(queue, callback, retryManager, rateLimit = 100) {
@@ -149,7 +150,7 @@ class Dequeuer {
 
     this.log(
       'debug',
-      `Message valid ${message.toString()}`,
+      `Message valid ${message.toString(removePIITransformer)}`,
       message,
       'success_dequeue_message_valid',
     );

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -59,7 +59,7 @@ class Message {
   }
 
   toString(transformer) {
-    let payload = this.payload;
+    let payload = Object.assign({}, this.payload);
     if (typeof transformer === 'function') {
       payload = transformer(payload);
     }

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -4,7 +4,6 @@ const Joi = require('joi');
 const uuidV4 = require('uuid/v4');
 const underscore = require('underscore');
 
-const removePIITransformer = require('../lib/helpers/logger/transformers/remove-pii');
 const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 const MessageValidationBlinkError = require('../errors/MessageValidationBlinkError');
 
@@ -59,7 +58,7 @@ class Message {
     return this.payload.meta.retryAttempt;
   }
 
-  toString(transformer = removePIITransformer) {
+  toString(transformer) {
     let payload = this.payload;
     if (typeof transformer === 'function') {
       payload = transformer(payload);

--- a/src/timers/RedisRetriesRepublishTimerTask.js
+++ b/src/timers/RedisRetriesRepublishTimerTask.js
@@ -7,6 +7,7 @@ const MessageParsingBlinkError = require('../errors/MessageParsingBlinkError');
 const MessageValidationBlinkError = require('../errors/MessageValidationBlinkError');
 const Message = require('../messages/Message');
 const RedisRetryDelayer = require('../lib/delayers/RedisRetryDelayer');
+const removePIITransformer = require('../lib/helpers/logger/transformers/remove-pii');
 const SkipTimer = require('./SkipTimer');
 
 // ------- Class ---------------------------------------------------------------
@@ -71,7 +72,7 @@ class RedisRetriesRepublishTimerTask extends SkipTimer {
     queue.publish(message, 'HIGH');
     this.log(
       'debug',
-      `Message sucesfully returned to queue ${queue.name}, ${message.toString()}`,
+      `Message sucesfully returned to queue ${queue.name}, ${message.toString(removePIITransformer)}`,
       message,
       'success_redis_republisher_message_republished',
     );
@@ -148,7 +149,7 @@ class RedisRetriesRepublishTimerTask extends SkipTimer {
 
     this.log(
       'debug',
-      `Message valid ${message.toString()}`,
+      `Message valid ${message.toString(removePIITransformer)}`,
       message,
       'success_redis_republisher_message_valid',
     );

--- a/src/web/controllers/WebController.js
+++ b/src/web/controllers/WebController.js
@@ -5,6 +5,7 @@ const URL = require('url');
 const BlinkError = require('../../errors/BlinkError');
 const logger = require('../../../config/logger');
 const MessageValidationBlinkError = require('../../errors/MessageValidationBlinkError');
+const removePIITransformer = require('../../lib/helpers/logger/transformers/remove-pii');
 
 class WebController {
   constructor(blink, router) {
@@ -95,7 +96,7 @@ class WebController {
   log(level, ctx, message, code) {
     let text = ctx.body ? ctx.body.message : undefined;
     if (message) {
-      text = `${text}, message ${message.toString()}`;
+      text = `${text}, message ${message.toString(removePIITransformer)}`;
     }
     const meta = {
       env: this.blink.config.app.env,

--- a/src/workers/CustomerIoTrackEventWorker.js
+++ b/src/workers/CustomerIoTrackEventWorker.js
@@ -4,6 +4,7 @@ const CIO = require('customerio-node');
 
 const BlinkRetryError = require('../errors/BlinkRetryError');
 const logger = require('../../config/logger');
+const removePIITransformer = require('../lib/helpers/logger/transformers/remove-pii');
 const Worker = require('./Worker');
 
 class CustomerIoTrackEventWorker extends Worker {
@@ -41,7 +42,7 @@ class CustomerIoTrackEventWorker extends Worker {
       };
       logger.warning(
         `Can't convert message to cio event: ${msgData.id} error ${error}`,
-        meta,
+        { meta },
       );
     }
 
@@ -81,7 +82,7 @@ class CustomerIoTrackEventWorker extends Worker {
       request_id: message ? message.getRequestId() : 'not_parsed',
     };
     // Todo: log error?
-    logger.log(level, `${text}, message ${message.toString()}`, { meta });
+    logger.log(level, `${text}, message ${message.toString(removePIITransformer)}`, { meta });
   }
 }
 

--- a/src/workers/CustomerIoUpdateCustomerWorker.js
+++ b/src/workers/CustomerIoUpdateCustomerWorker.js
@@ -5,6 +5,7 @@ const CIO = require('customerio-node');
 const BlinkRetryError = require('../errors/BlinkRetryError');
 const CustomerIoUpdateCustomerMessage = require('../messages/CustomerIoUpdateCustomerMessage');
 const logger = require('../../config/logger');
+const removePIITransformer = require('../lib/helpers/logger/transformers/remove-pii');
 const Worker = require('./Worker');
 
 class CustomerIoUpdateCustomerWorker extends Worker {
@@ -31,7 +32,7 @@ class CustomerIoUpdateCustomerWorker extends Worker {
       };
       logger.warning(
         `Can't convert user to cio customer: ${userMessage.getData().id} error ${error}`,
-        meta,
+        { meta },
       );
     }
 
@@ -70,7 +71,7 @@ class CustomerIoUpdateCustomerWorker extends Worker {
       request_id: message ? message.getRequestId() : 'not_parsed',
     };
     // Todo: log error?
-    logger.log(level, `${text}, message ${message.toString()}`, { meta });
+    logger.log(level, `${text}, message ${message.toString(removePIITransformer)}`, { meta });
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

It requires a transformer to be passed to the `Message.toString()` functions in order to transform its payload instead of using the removePII transformer by default.

This fixes the bug where we were compulsively stripping PII from all message payloads by default. Because in order to publish a message's payload to our queues we need to convert it to a string. The `Message.toString()` method was called right before publishing, stripping the PII for us too!

## How to test
- test updating PII in `Admin-qa` and seeing the profile change in C.io.

## Tasks
- [x] Deploy to staging
- [x] Test in staging.