### PR TITLE
make mobile optional for broadcasts [pr]

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,34 @@
+_BUG_
+-------------------
+#### Current Behavior
+- tell us what happened
+
+#### Desired Behavior
+- what should have happened
+
+#### Steps to Replicate
+- how can you make it happen every time?
+
+#### Why This Matters
+
+#### Relevant Screenshots + Links
+
+_FEATURE OVERVIEW_
+-------------------
+#### User Story
+
+#### Additional Information (optional)
+
+#### Why This Matters
+
+#### Current Workaround w/o Feature (if applicable)
+
+_HACK DOCUMENTATION_
+-------------------
+#### Related Issue
+
+#### Affected Pages
+
+#### Hack Explanation
+
+#### Please note if this needs to be undone at some point and why.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+#### What's this PR do?
+tell us, what have you changed?
+
+#### How should this be reviewed?
+tell us, how can we review, to test that this works
+
+#### Any background context you want to provide?
+what else?
+
+#### Relevant tickets
+Fixes #
+Fixes Pivotal [Card#]()
+
+#### Checklist
+- [ ] Documentation added for new features/changed endpoints.
+- [ ] Tests added/updated for new features/bug fixes.
+- [ ] ENV variables added/updated for new features/bug fixes.
+- [ ] Tested on staging.
+- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.

--- a/src/messages/CustomerIoGambitBroadcastMessage.js
+++ b/src/messages/CustomerIoGambitBroadcastMessage.js
@@ -13,7 +13,7 @@ class CustomerIoGambitBroadcastMessage extends Message {
       .keys({
         northstarId: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
         broadcastId: Joi.string().required().empty(whenNullOrEmpty),
-        mobile: Joi.string().required().empty(whenNullOrEmpty),
+        mobile: Joi.string().empty(whenNullOrEmpty),
       });
   }
 

--- a/src/workers/lib/helpers/gambit-conversations.js
+++ b/src/workers/lib/helpers/gambit-conversations.js
@@ -94,6 +94,16 @@ module.exports.getBroadcastPath = function getBroadcastPath() {
 };
 
 /**
+ * getBroadcastLitePath
+ *
+ * @see https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/messages.md#broadcast-lite
+ * @return {String}   G-Conversations broadcastLite message path
+ */
+module.exports.getBroadcastLitePath = function getBroadcastLitePath() {
+  return 'messages?origin=broadcastLite';
+};
+
+/**
  * getCampaignSignupPath
  *
  * @see https://github.com/DoSomething/gambit-conversations/blob/master/documentation/endpoints/messages.md#signup
@@ -140,6 +150,7 @@ module.exports.relayTwilioInboundMessage = function relayTwilioInboundMessage(me
 
 /**
  * relayBroadcastMessage - Relays Broadcast messages to G-Conversations
+ *                         /v2/messages?origin=broadcast route
  *
  * @param  {Message} message
  * @param  {Object} opts
@@ -147,6 +158,17 @@ module.exports.relayTwilioInboundMessage = function relayTwilioInboundMessage(me
  */
 module.exports.relayBroadcastMessage = function relayBroadcastMessage(message, opts) {
   return exports.relayMessage(exports.getBroadcastPath(), message, opts);
+};
+
+/**
+ * relayBroadcastLiteMessage - Relays Broadcast message to G-Conversations
+ *                             /v2/messages?origin=broadcastLite route
+ * @param {*} message
+ * @param {*} opts
+ * @return {Promise<Response>}
+ */
+module.exports.relayBroadcastLiteMessage = function relayBroadcastLiteMessage(message, opts) {
+  return exports.relayMessage(exports.getBroadcastLitePath(), message, opts);
 };
 
 /**

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -23,7 +23,7 @@ const chance = new Chance();
 // ------- Helpers -------------------------------------------------------------
 
 class MessageFactoryHelper {
-  static getValidUser() {
+  static getUserMessage() {
     const fakeId = MessageFactoryHelper.getFakeUserId();
     const createdAt = chance.date({ year: chance.year({ min: 2000, max: 2010 }) }).toISOString();
     return new UserMessage({
@@ -77,7 +77,7 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidCustomerIoIdentify() {
+  static getCustomerIoUpdateCustomerMessage() {
     const fakeId = MessageFactoryHelper.getFakeUserId();
     return new CustomerIoUpdateCustomerMessage({
       data: {
@@ -118,36 +118,7 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidTwilioInboundData() {
-    const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
-    return new FreeFormMessage({
-      data: {
-        ToCountry: 'US',
-        ToState: '',
-        SmsMessageSid: sid,
-        NumMedia: '0',
-        ToCity: '',
-        FromZip: chance.zip(),
-        SmsSid: sid,
-        FromState: chance.state({ territories: true }),
-        SmsStatus: 'received',
-        FromCity: chance.city(),
-        Body: '',
-        FromCountry: 'US',
-        To: '38383',
-        MessagingServiceSid: sid,
-        ToZip: '',
-        NumSegments: '1',
-        MessageSid: sid,
-        AccountSid: sid,
-        From: MessageFactoryHelper.getFakeMobileNumber(),
-        ApiVersion: '2010-04-01',
-      },
-      meta: {},
-    });
-  }
-
-  static getValidTwilioOutboundStatusData(deliveredAt) {
+  static getTwilioOutboundDeliveredStatusMessage(deliveredAt) {
     const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
     const msg = new TwilioOutboundStatusCallbackMessage({
       data: {
@@ -168,7 +139,7 @@ class MessageFactoryHelper {
     return msg;
   }
 
-  static getValidTwilioOutboundErrorStatusData(failedAt) {
+  static getTwilioOutboundErrorStatusMessage(failedAt) {
     const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
     const msg = new TwilioOutboundStatusCallbackMessage({
       data: {
@@ -191,7 +162,7 @@ class MessageFactoryHelper {
     return msg;
   }
 
-  static getValidInboundMessageData() {
+  static getTwilioInboundMessage() {
     const sid = `${chance.pickone(['SM', 'MM'])}${chance.hash({ length: 32 })}`;
     return new FreeFormMessage({
       data: {
@@ -220,7 +191,7 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidCampaignSignup() {
+  static getCampaignSignupMessage() {
     const createdAt = chance.date({ year: (new Date()).getFullYear() }).toISOString();
     const updatedAt = moment(createdAt).add(1, 'days').toISOString();
 
@@ -241,7 +212,7 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidCampaignSignupPostData() {
+  static getCampaignSignupPostMessageData() {
     const createdAt = chance.date({ year: (new Date()).getFullYear() }).toISOString();
     const updatedAt = moment(createdAt).add(1, 'days').toISOString();
     const deletedAt = moment(createdAt).add(2, 'days').toISOString();
@@ -278,8 +249,8 @@ class MessageFactoryHelper {
     return data;
   }
 
-  static getValidCampaignSignupPost() {
-    const data = MessageFactoryHelper.getValidCampaignSignupPostData();
+  static getCampaignSignupPostMessage() {
+    const data = MessageFactoryHelper.getCampaignSignupPostMessageData();
 
     return new CampaignSignupPostMessage({
       data,
@@ -287,8 +258,8 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidCampaignSignupPostReview() {
-    const data = MessageFactoryHelper.getValidCampaignSignupPostData();
+  static getCampaignSignupPostMessageReviewMessage() {
+    const data = MessageFactoryHelper.getCampaignSignupPostMessageData();
 
     return new CampaignSignupPostReviewMessage({
       data,
@@ -354,7 +325,11 @@ class MessageFactoryHelper {
     return chance.hash({ length: 24 });
   }
 
-  static getValidGambitBroadcastData(broadcastId) {
+  static getBroadcastId() {
+    return chance.word();
+  }
+
+  static getGambitBroadcastMessage(broadcastId = MessageFactoryHelper.getBroadcastId()) {
     return new CustomerIoGambitBroadcastMessage({
       data: {
         northstarId: MessageFactoryHelper.getFakeUserId(),
@@ -365,7 +340,7 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidSmsActiveData() {
+  static getSmsActiveMessage() {
     return new CustomerIoSmsStatusActiveMessage({
       data: {
         northstarId: MessageFactoryHelper.getFakeUserId(),
@@ -374,7 +349,7 @@ class MessageFactoryHelper {
     });
   }
 
-  static getValidCustomerIoWebhookData() {
+  static getCustomerIoWebhookData() {
     return {
       data: {
         campaign_id: chance.integer({ min: 0 }),
@@ -390,8 +365,8 @@ class MessageFactoryHelper {
     };
   }
 
-  static getValidCustomerIoWebhookMessage(eventType) {
-    const data = MessageFactoryHelper.getValidCustomerIoWebhookData();
+  static getCustomerIoWebhookMessage(eventType) {
+    const data = MessageFactoryHelper.getCustomerIoWebhookData();
     data.event_type = eventType || chance.word();
     return new CustomerIoWebhookMessage({
       data,

--- a/test/integration/web/controllers/EventsWebController.test.js
+++ b/test/integration/web/controllers/EventsWebController.test.js
@@ -156,7 +156,7 @@ test('POST /api/v1/events/user-signup should validate incoming message', async (
  * POST /api/v1/events/user-signup
  */
 test('POST /api/v1/events/user-signup should publish message to user-signup-event', async (t) => {
-  const data = MessageFactoryHelper.getValidCampaignSignup().getData();
+  const data = MessageFactoryHelper.getCampaignSignupMessage().getData();
   const res = await t.context.supertest.post('/api/v1/events/user-signup')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
     .send(data);
@@ -207,7 +207,7 @@ test('POST /api/v1/events/user-signup should publish message to user-signup-even
  * POST /api/v1/events/user-signup-post
  */
 test('POST /api/v1/events/user-signup-post should publish message to user-signup-post-event', async (t) => {
-  const data = MessageFactoryHelper.getValidCampaignSignupPost().getData();
+  const data = MessageFactoryHelper.getCampaignSignupPostMessage().getData();
 
   const res = await t.context.supertest.post('/api/v1/events/user-signup-post')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
@@ -244,7 +244,7 @@ test('POST /api/v1/events/user-signup-post should publish message to user-signup
  * POST /api/v1/events/user-signup-post-review
  */
 test('POST /api/v1/events/user-signup-post-review should publish message to user-signup-post-review-event', async (t) => {
-  const data = MessageFactoryHelper.getValidCampaignSignupPostReview().getData();
+  const data = MessageFactoryHelper.getCampaignSignupPostMessageReviewMessage().getData();
 
   const res = await t.context.supertest.post('/api/v1/events/user-signup-post-review')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -3,7 +3,6 @@
 // ------- Imports -------------------------------------------------------------
 
 const chai = require('chai');
-const Chance = require('chance');
 const test = require('ava');
 
 const RabbitManagement = require('../../../helpers/RabbitManagement');
@@ -16,8 +15,6 @@ const twilioHelper = require('../../../helpers/twilio');
 chai.should();
 test.beforeEach(HooksHelper.startBlinkWebApp);
 test.afterEach(HooksHelper.stopBlinkWebApp);
-
-const chance = new Chance();
 
 // ------- Tests ---------------------------------------------------------------
 
@@ -56,7 +53,7 @@ test('GET /api/v1/webhooks should respond with JSON list available webhooks', as
  * POST /api/v1/webhooks/customerio
  */
 test.serial('POST /api/v1/webhooks/customerio-email-activity should publish message to customer-io queue', async (t) => {
-  const data = MessageFactoryHelper.getValidCustomerIoWebhookData();
+  const data = MessageFactoryHelper.getCustomerIoWebhookData();
 
   const res = await t.context.supertest.post('/api/v1/webhooks/customerio-email-activity')
     .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
@@ -85,7 +82,7 @@ test.serial('POST /api/v1/webhooks/customerio-email-activity should publish mess
 });
 
 test.serial('POST /api/v1/webhooks/customerio-email-activity should publish email_unsubscribed events to the quasar-customer-io-email-activity and quasar-customer-io-email-unsubscribed queues', async (t) => {
-  const data = MessageFactoryHelper.getValidCustomerIoWebhookData();
+  const data = MessageFactoryHelper.getCustomerIoWebhookData();
   data.event_type = 'email_unsubscribed';
 
   const res = await t.context.supertest.post('/api/v1/webhooks/customerio-email-activity')
@@ -140,7 +137,7 @@ test('POST /api/v1/webhooks/twilio-sms-inbound should fail with 403 forbidden fo
  * POST /api/v1/webhooks/twilio-sms-inbound
  */
 test('POST /api/v1/webhooks/twilio-sms-inbound should be queued when a valid x-twilio-signature is received', async (t) => {
-  const message = MessageFactoryHelper.getValidTwilioInboundData();
+  const message = MessageFactoryHelper.getTwilioInboundMessage();
   const data = message.getData();
 
   const serverAddress = t.context.blink.web.server.address();
@@ -175,9 +172,8 @@ test('POST /api/v1/webhooks/twilio-sms-inbound should be queued when a valid x-t
 /**
  * POST /api/v1/webhooks/customerio-gambit-broadcast
  */
-test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming payload', async (t) => {
-  const broadcastId = chance.word();
-  const data = MessageFactoryHelper.getValidGambitBroadcastData(broadcastId).getData();
+test('POST /api/v1/webhooks/customerio-gambit-broadcast responds w/ 422 if northstarId is missing', async (t) => {
+  const data = MessageFactoryHelper.getGambitBroadcastMessage().getData();
   delete data.northstarId;
 
   const res = await t.context.supertest.post('/api/v1/webhooks/customerio-gambit-broadcast')
@@ -191,11 +187,55 @@ test('POST /api/v1/webhooks/customerio-gambit-broadcast validates incoming paylo
     .and.have.string('"northstarId" is required');
 });
 
+test('POST /api/v1/webhooks/customerio-gambit-broadcast responds w/ 422 if broadcastId is missing', async (t) => {
+  const data = MessageFactoryHelper.getGambitBroadcastMessage().getData();
+  delete data.broadcastId;
+
+  const res = await t.context.supertest.post('/api/v1/webhooks/customerio-gambit-broadcast')
+    .set('Content-Type', 'application/x-www-form-urlencoded')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(422);
+  res.body.should.have.property('ok', false);
+  res.body.should.have.property('message')
+    .and.have.string('"broadcastId" is required');
+});
+
+test('POST /api/v1/webhooks/customerio-gambit-broadcast responds w/ 201 if mobile is missing (is optional)', async (t) => {
+  const data = MessageFactoryHelper.getGambitBroadcastMessage().getData();
+  delete data.mobile;
+
+  const res = await t.context.supertest.post('/api/v1/webhooks/customerio-gambit-broadcast')
+    .set('Content-Type', 'application/x-www-form-urlencoded')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(201);
+  res.body.should.have.property('ok', true);
+  res.body.should.have.property('code')
+    .and.have.string('success_message_queued');
+});
+
+test('POST /api/v1/webhooks/customerio-gambit-broadcast responds w/ 201 if message is valid', async (t) => {
+  const data = MessageFactoryHelper.getGambitBroadcastMessage().getData();
+
+  const res = await t.context.supertest.post('/api/v1/webhooks/customerio-gambit-broadcast')
+    .set('Content-Type', 'application/x-www-form-urlencoded')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(201);
+  res.body.should.have.property('ok', true);
+  res.body.should.have.property('code')
+    .and.have.string('success_message_queued');
+});
+
 /**
  * POST /api/v1/webhooks/customerio-sms-status-active
  */
 test('POST /api/v1/webhooks/customerio-sms-status-active validates incoming payload', async (t) => {
-  const data = MessageFactoryHelper.getValidSmsActiveData().getData();
+  const data = MessageFactoryHelper.getSmsActiveMessage().getData();
   delete data.northstarId;
 
   const res = await t.context.supertest.post('/api/v1/webhooks/customerio-sms-status-active')
@@ -213,7 +253,7 @@ test('POST /api/v1/webhooks/customerio-sms-status-active validates incoming payl
  * POST /api/v1/webhooks/twilio-sms-outbound-status
  */
 test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-status-relay when a valid x-twilio-signature is received', async (t) => {
-  const message = MessageFactoryHelper.getValidTwilioOutboundStatusData();
+  const message = MessageFactoryHelper.getTwilioOutboundDeliveredStatusMessage();
   const data = message.getData();
 
   const serverAddress = t.context.blink.web.server.address();
@@ -257,7 +297,7 @@ test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twili
  * POST /api/v1/webhooks/twilio-sms-outbound-status
  */
 test('POST /api/v1/webhooks/twilio-sms-outbound-status should be queued in twilio-sms-outbound-error-relay when a valid x-twilio-signature is received', async (t) => {
-  const message = MessageFactoryHelper.getValidTwilioOutboundErrorStatusData();
+  const message = MessageFactoryHelper.getTwilioOutboundErrorStatusMessage();
   const data = message.getData();
 
   const serverAddress = t.context.blink.web.server.address();

--- a/test/integration/workers/CustomerIoGambitBroadcastWorker.test.js
+++ b/test/integration/workers/CustomerIoGambitBroadcastWorker.test.js
@@ -27,14 +27,15 @@ const chance = new Chance();
  * by the GAMBIT_BROADCAST_SPEED_LIMIT env variable
  */
 test.serial('Gambit Broadcast relay should be consume close to 50 messages per second', async (t) => {
-  // Turn off extra logs for this tests, as it genertes thouthands of messages.
+  // Turn off extra logs for this tests, as it generates thousands of messages.
   await HooksHelper.startBlinkWebApp(t);
   const blink = t.context.blink;
   const { customerIoGambitBroadcastQ } = blink.queues;
 
   // Publish 2x rate limit messages to the queue
   for (let i = 0; i < 120; i++) {
-    const message = MessageFactoryHelper.getValidGambitBroadcastData();
+    const message = MessageFactoryHelper.getGambitBroadcastMessage();
+    message.validate();
     message.payload.meta.request_id = chance.guid({ version: 4 });
     customerIoGambitBroadcastQ.publish(message);
   }
@@ -74,7 +75,7 @@ test.serial('POST /api/v1/webhooks/customerio-gambit-broadcast should publish me
   await HooksHelper.startBlinkWebApp(t);
 
   const broadcastId = chance.word();
-  const data = MessageFactoryHelper.getValidGambitBroadcastData(broadcastId).getData();
+  const data = MessageFactoryHelper.getGambitBroadcastMessage(broadcastId).getData();
 
   const res = await t.context.supertest.post('/api/v1/webhooks/customerio-gambit-broadcast')
     .set('Content-Type', 'application/json')

--- a/test/unit/messages/CampaignSignupMessage.test.js
+++ b/test/unit/messages/CampaignSignupMessage.test.js
@@ -14,7 +14,7 @@ const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
 
 chai.should();
 const expect = chai.expect;
-const generator = MessageFactoryHelper.getValidCampaignSignup;
+const generator = MessageFactoryHelper.getCampaignSignupMessage;
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/test/unit/messages/CampaignSignupPostMessage.test.js
+++ b/test/unit/messages/CampaignSignupPostMessage.test.js
@@ -14,7 +14,7 @@ const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
 
 chai.should();
 const expect = chai.expect;
-const generator = MessageFactoryHelper.getValidCampaignSignupPost;
+const generator = MessageFactoryHelper.getCampaignSignupPostMessage;
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/test/unit/messages/CampaignSignupPostReviewMessage.test.js
+++ b/test/unit/messages/CampaignSignupPostReviewMessage.test.js
@@ -11,7 +11,7 @@ const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const generator = MessageFactoryHelper.getValidCampaignSignupPostReview;
+const generator = MessageFactoryHelper.getCampaignSignupPostMessageReviewMessage;
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/test/unit/messages/CustomerIoGambitBroadcastMessage.test.js
+++ b/test/unit/messages/CustomerIoGambitBroadcastMessage.test.js
@@ -12,7 +12,7 @@ const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const generator = MessageFactoryHelper.getValidGambitBroadcastData;
+const generator = MessageFactoryHelper.getGambitBroadcastMessage;
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/test/unit/messages/CustomerIoSmsStatusActiveMessage.test.js
+++ b/test/unit/messages/CustomerIoSmsStatusActiveMessage.test.js
@@ -12,7 +12,7 @@ const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const generator = MessageFactoryHelper.getValidSmsActiveData;
+const generator = MessageFactoryHelper.getSmsActiveMessage;
 
 // ------- Tests ---------------------------------------------------------------
 

--- a/test/unit/messages/CustomerIoUpdateCustomerMessage.test.js
+++ b/test/unit/messages/CustomerIoUpdateCustomerMessage.test.js
@@ -13,7 +13,7 @@ const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const generator = MessageFactoryHelper.getValidCustomerIoIdentify;
+const generator = MessageFactoryHelper.getCustomerIoUpdateCustomerMessage;
 
 // ------- Tests ---------------------------------------------------------------
 
@@ -24,7 +24,7 @@ test('User message generator', () => {
 test('Cio identify created from Northstar is correct', () => {
   let count = 100;
   while (count > 0) {
-    const userMessage = MessageFactoryHelper.getValidUser();
+    const userMessage = MessageFactoryHelper.getUserMessage();
     userMessage.validate();
     const userData = userMessage.getData();
     const customerIoUpdateCustomerMessage = CustomerIoUpdateCustomerMessage.fromUser(
@@ -64,7 +64,7 @@ test('Cio identify created from Northstar is correct when unsubscribed is set', 
   let count = 100;
   while (count > 0) {
     const shouldSetUnsubscribed = count % 2 === 0;
-    const userMessage = MessageFactoryHelper.getValidUser();
+    const userMessage = MessageFactoryHelper.getUserMessage();
     userMessage.validate();
     // Set unsubscribed
     userMessage.payload.data.unsubscribed = shouldSetUnsubscribed;

--- a/test/unit/messages/CustomerIoWebhookMessage.test.js
+++ b/test/unit/messages/CustomerIoWebhookMessage.test.js
@@ -12,7 +12,7 @@ const customerIoWebhookConfig = require('../../../config/messages/CustomerIoWebh
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const generator = MessageFactoryHelper.getValidCustomerIoWebhookMessage;
+const generator = MessageFactoryHelper.getCustomerIoWebhookMessage;
 
 // ------- Tests ---------------------------------------------------------------
 
@@ -29,20 +29,20 @@ test('C.io webhook message should respond to getUserId, getEventType, and getEve
 
 test('An email_unsubscribed event message should get the email_unsubscribed routing key when calling getEventRoutingKey()', () => {
   const emailUnsubscribedRoutingKey = customerIoWebhookConfig.events.email_unsubscribed.routingKey;
-  const msg = MessageFactoryHelper.getValidCustomerIoWebhookMessage('email_unsubscribed');
+  const msg = MessageFactoryHelper.getCustomerIoWebhookMessage('email_unsubscribed');
   const routingKey = msg.getEventRoutingKey();
   routingKey.should.be.equal(emailUnsubscribedRoutingKey);
 });
 
 test('Any non specialized event message should get the generic routing key when calling getEventRoutingKey()', () => {
   const genericRoutingKey = customerIoWebhookConfig.events.generic.routingKey;
-  const msg = MessageFactoryHelper.getValidCustomerIoWebhookMessage();
+  const msg = MessageFactoryHelper.getCustomerIoWebhookMessage();
   const routingKey = msg.getEventRoutingKey();
   routingKey.should.be.equal(genericRoutingKey);
 });
 
 test('C.io webhook message should return the data.customer_id propety when calling getUserId()', () => {
-  const msg = MessageFactoryHelper.getValidCustomerIoWebhookMessage();
+  const msg = MessageFactoryHelper.getCustomerIoWebhookMessage();
   const userId = msg.getUserId();
   userId.should.be.equal(msg.payload.data.data.customer_id);
 });

--- a/test/unit/messages/TwilioOutboundStatusCallbackMessage.test.js
+++ b/test/unit/messages/TwilioOutboundStatusCallbackMessage.test.js
@@ -12,16 +12,16 @@ const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
 // ------- Init ----------------------------------------------------------------
 
 const should = chai.should();
-const generator = MessageFactoryHelper.getValidTwilioOutboundStatusData;
 
 // ------- Tests ---------------------------------------------------------------
 
 test('Twilio outbound status callback message generator', () => {
-  generator().should.be.an.instanceof(TwilioOutboundStatusCallbackMessage);
+  MessageFactoryHelper.getTwilioOutboundDeliveredStatusMessage()
+    .should.be.an.instanceof(TwilioOutboundStatusCallbackMessage);
 });
 
 test('Twilio outbound status callback message should respond to isError, isDelivered, setDeliveredAt, and setFailedAt', () => {
-  const msg = generator();
+  const msg = MessageFactoryHelper.getTwilioOutboundDeliveredStatusMessage();
   msg.should.respondsTo('isError');
   msg.should.respondsTo('isDelivered');
   msg.should.respondsTo('setDeliveredAt');
@@ -29,7 +29,7 @@ test('Twilio outbound status callback message should respond to isError, isDeliv
 });
 
 test('Twilio outbound status callback message should set deliveredAt', () => {
-  const msg = generator();
+  const msg = MessageFactoryHelper.getTwilioOutboundDeliveredStatusMessage();
   should.not.exist(msg.getData().deliveredAt);
 
   msg.setDeliveredAt(moment().format());
@@ -37,7 +37,7 @@ test('Twilio outbound status callback message should set deliveredAt', () => {
 });
 
 test('Twilio outbound status callback message should set failedAt', () => {
-  const msg = MessageFactoryHelper.getValidTwilioOutboundErrorStatusData();
+  const msg = MessageFactoryHelper.getTwilioOutboundErrorStatusMessage();
   should.not.exist(msg.getData().failedAt);
 
   msg.setFailedAt(moment().format());

--- a/test/unit/messages/UserMessage.test.js
+++ b/test/unit/messages/UserMessage.test.js
@@ -13,7 +13,7 @@ const MessageValidationHelper = require('../../helpers/MessageValidationHelper')
 // ------- Init ----------------------------------------------------------------
 
 chai.should();
-const generator = MessageFactoryHelper.getValidUser;
+const generator = MessageFactoryHelper.getUserMessage;
 const mutator = function ({ remove, change, value, message }) {
   const mutant = message;
   if (remove) {

--- a/test/unit/workers/CustomerIoEmailUnsubscribedNorthstarWorker.test.js
+++ b/test/unit/workers/CustomerIoEmailUnsubscribedNorthstarWorker.test.js
@@ -36,16 +36,16 @@ test('getLogCode should be setup and have correct logs', () => {
 test('Northstar should receive correct retry count if message has been retried', async () => {
   // No retry property:
   const headers = await northstarHelper
-    .getRequestHeaders(MessageFactoryHelper.getValidCustomerIoWebhookMessage());
+    .getRequestHeaders(MessageFactoryHelper.getCustomerIoWebhookMessage());
   headers.should.not.have.property('x-blink-retry-count');
 
   // retry = 0
-  const retriedZero = MessageFactoryHelper.getValidCustomerIoWebhookMessage();
+  const retriedZero = MessageFactoryHelper.getCustomerIoWebhookMessage();
   const headersRetry0 = await northstarHelper.getRequestHeaders(retriedZero);
   headersRetry0.should.not.have.property('x-blink-retry-count');
 
   // retry = 1
-  const retriedOnce = MessageFactoryHelper.getValidCustomerIoWebhookMessage();
+  const retriedOnce = MessageFactoryHelper.getCustomerIoWebhookMessage();
   retriedOnce.incrementRetryAttempt();
   const headersRetry1 = await northstarHelper.getRequestHeaders(retriedOnce);
   headersRetry1.should.have.property('x-blink-retry-count').and.equal(1);

--- a/test/unit/workers/CustomerIoGambitBroadcastWorker.test.js
+++ b/test/unit/workers/CustomerIoGambitBroadcastWorker.test.js
@@ -32,16 +32,16 @@ test('Gambit Broadcast relay should receive correct retry count if message has b
   const broadcastId = MessageFactoryHelper.getFakeUserId();
 
   // No retry property:
-  gambitHelper.getRequestHeaders(MessageFactoryHelper.getValidGambitBroadcastData(broadcastId))
+  gambitHelper.getRequestHeaders(MessageFactoryHelper.getGambitBroadcastMessage(broadcastId))
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 0
-  const retriedZero = MessageFactoryHelper.getValidGambitBroadcastData(broadcastId);
+  const retriedZero = MessageFactoryHelper.getGambitBroadcastMessage(broadcastId);
   gambitHelper.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
-  const retriedOnce = MessageFactoryHelper.getValidGambitBroadcastData(broadcastId);
+  const retriedOnce = MessageFactoryHelper.getGambitBroadcastMessage(broadcastId);
   retriedOnce.incrementRetryAttempt();
   gambitHelper.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);

--- a/test/unit/workers/CustomerIoSmsStatusActiveWorker.test.js
+++ b/test/unit/workers/CustomerIoSmsStatusActiveWorker.test.js
@@ -30,16 +30,16 @@ test('getLogCode should be setup and have correct logs', () => {
 
 test('Gambit Sms Status Active relay should receive correct retry count if message has been retried', () => {
   // No retry property:
-  gambitHelper.getRequestHeaders(MessageFactoryHelper.getValidSmsActiveData())
+  gambitHelper.getRequestHeaders(MessageFactoryHelper.getSmsActiveMessage())
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 0
-  const retriedZero = MessageFactoryHelper.getValidSmsActiveData();
+  const retriedZero = MessageFactoryHelper.getSmsActiveMessage();
   gambitHelper.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
-  const retriedOnce = MessageFactoryHelper.getValidSmsActiveData();
+  const retriedOnce = MessageFactoryHelper.getSmsActiveMessage();
   retriedOnce.incrementRetryAttempt();
   gambitHelper.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);

--- a/test/unit/workers/GambitCampaignSignupRelayWorker.test.js
+++ b/test/unit/workers/GambitCampaignSignupRelayWorker.test.js
@@ -32,16 +32,16 @@ test('getLogCode should be setup and have correct logs', () => {
 
 test('Gambit should receive correct retry count if message has been retried', () => {
   // No retry property:
-  gambitHelper.getRequestHeaders(MessageFactoryHelper.getValidCampaignSignup())
+  gambitHelper.getRequestHeaders(MessageFactoryHelper.getCampaignSignupMessage())
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 0
-  const retriedZero = MessageFactoryHelper.getValidCampaignSignup();
+  const retriedZero = MessageFactoryHelper.getCampaignSignupMessage();
   gambitHelper.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
-  const retriedOnce = MessageFactoryHelper.getValidCampaignSignup();
+  const retriedOnce = MessageFactoryHelper.getCampaignSignupMessage();
   retriedOnce.incrementRetryAttempt();
   gambitHelper.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);
@@ -49,12 +49,12 @@ test('Gambit should receive correct retry count if message has been retried', ()
 
 test('Gambit should receive signups not created by Gambit', () => {
   // Helper specifically will not return sms-related signup source.
-  const message = MessageFactoryHelper.getValidCampaignSignup();
+  const message = MessageFactoryHelper.getCampaignSignupMessage();
   GambitCampaignSignupRelayWorker.shouldSkip(message).should.be.false;
 });
 
 test('Gambit should not recieve signups created by Gambit', () => {
-  const message = MessageFactoryHelper.getValidCampaignSignup();
+  const message = MessageFactoryHelper.getCampaignSignupMessage();
   const smsRelatedSources = [
     'sms',
     `sms${chance.word()}`,

--- a/test/unit/workers/TwilioSmsInboundGambitRelayWorker.test.js
+++ b/test/unit/workers/TwilioSmsInboundGambitRelayWorker.test.js
@@ -30,16 +30,16 @@ test('getLogCode should be setup and have correct logs', () => {
 
 test('Gambit Broadcast relay should receive correct retry count if message has been retried', () => {
   // No retry property:
-  gambitHelper.getRequestHeaders(MessageFactoryHelper.getValidInboundMessageData())
+  gambitHelper.getRequestHeaders(MessageFactoryHelper.getTwilioInboundMessage())
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 0
-  const retriedZero = MessageFactoryHelper.getValidInboundMessageData();
+  const retriedZero = MessageFactoryHelper.getTwilioInboundMessage();
   gambitHelper.getRequestHeaders(retriedZero)
     .should.not.have.property('x-blink-retry-count');
 
   // retry = 1
-  const retriedOnce = MessageFactoryHelper.getValidInboundMessageData();
+  const retriedOnce = MessageFactoryHelper.getTwilioInboundMessage();
   retriedOnce.incrementRetryAttempt();
   gambitHelper.getRequestHeaders(retriedOnce)
     .should.have.property('x-blink-retry-count').and.equal(1);

--- a/test/unit/workers/lib/lib-helpers/gambit-conversations.test.js
+++ b/test/unit/workers/lib/lib-helpers/gambit-conversations.test.js
@@ -41,7 +41,7 @@ test('parseMessageIdFromBody should not throw when body is a non empty array', (
 
 // getFailedAtUpdateBody
 test('getFailedAtUpdateBody should return a valid payload', () => {
-  const message = messageFactoryHelper.getValidTwilioOutboundErrorStatusData(moment().format());
+  const message = messageFactoryHelper.getTwilioOutboundErrorStatusMessage(moment().format());
   const payload = gambitHelper.getFailedAtUpdateBody(message.getData());
   payload.metadata.delivery.failedAt.should.exist;
   payload.metadata.delivery.failureData.code.exist;
@@ -50,7 +50,7 @@ test('getFailedAtUpdateBody should return a valid payload', () => {
 
 // getDeliveredAtUpdateBody
 test('getDeliveredAtUpdateBody should return a valid payload', () => {
-  const message = messageFactoryHelper.getValidTwilioOutboundStatusData(moment().format());
+  const message = messageFactoryHelper.getTwilioOutboundDeliveredStatusMessage(moment().format());
   const payload = gambitHelper.getDeliveredAtUpdateBody(message.getData());
   payload.metadata.delivery.deliveredAt.should.exist;
 });
@@ -71,7 +71,7 @@ test.serial('updateMessage should call executeUpdate', async () => {
 test.serial('getMessageToUpdate should call getMessageIdBySid', async () => {
   sandbox.stub(gambitHelper, 'getMessageIdBySid')
     .returns(Promise.resolve(true));
-  const message = messageFactoryHelper.getValidTwilioOutboundStatusData(moment().format());
+  const message = messageFactoryHelper.getTwilioOutboundDeliveredStatusMessage(moment().format());
   const messageSid = message.getData().MessageSid;
   const headers = gambitHelper.getRequestHeaders(message);
 
@@ -93,7 +93,7 @@ test.serial('getMessageIdBySid should call executeGet', async () => {
 
 // getRequestHeaders
 test('getRequestHeaders should return valid headers', () => {
-  const message = messageFactoryHelper.getValidTwilioOutboundStatusData(moment().format());
+  const message = messageFactoryHelper.getTwilioOutboundDeliveredStatusMessage(moment().format());
 
   const headers = gambitHelper.getRequestHeaders(message);
   should.exist(headers.Authorization);
@@ -105,7 +105,7 @@ test('getRequestHeaders should return valid headers', () => {
 test.serial('relaySmsStatusActiveMessage should relay the message to the correct path', async () => {
   sandbox.stub(gambitHelper, 'relayMessage')
     .returns(Promise.resolve(true));
-  const message = messageFactoryHelper.getValidSmsActiveData();
+  const message = messageFactoryHelper.getSmsActiveMessage();
   const path = gambitHelper.getSubscriptionStatusActivePath();
   const opts = {
     body: JSON.stringify({ hello: 'world' }),
@@ -119,7 +119,7 @@ test.serial('relaySmsStatusActiveMessage should relay the message to the correct
 test.serial('relayCampaignSignupMessage should relay the message to the correct path', async () => {
   sandbox.stub(gambitHelper, 'relayMessage')
     .returns(Promise.resolve(true));
-  const message = messageFactoryHelper.getValidCampaignSignup();
+  const message = messageFactoryHelper.getCampaignSignupMessage();
   const path = gambitHelper.getCampaignSignupPath();
   const opts = {
     body: JSON.stringify({ hello: 'world' }),
@@ -133,7 +133,7 @@ test.serial('relayCampaignSignupMessage should relay the message to the correct 
 test.serial('relayBroadcastMessage should relay the message to the correct path', async () => {
   sandbox.stub(gambitHelper, 'relayMessage')
     .returns(Promise.resolve(true));
-  const message = messageFactoryHelper.getValidGambitBroadcastData();
+  const message = messageFactoryHelper.getGambitBroadcastMessage();
   const path = gambitHelper.getBroadcastPath();
   const opts = {
     body: JSON.stringify({ hello: 'world' }),
@@ -147,7 +147,7 @@ test.serial('relayBroadcastMessage should relay the message to the correct path'
 test.serial('relayTwilioInboundMessage should relay the message to the correct path', async () => {
   sandbox.stub(gambitHelper, 'relayMessage')
     .returns(Promise.resolve(true));
-  const message = messageFactoryHelper.getValidInboundMessageData();
+  const message = messageFactoryHelper.getTwilioInboundMessage();
   const path = gambitHelper.getTwilioPath();
   const opts = {
     body: JSON.stringify({ hello: 'world' }),


### PR DESCRIPTION
#### What's this PR do?
- Makes `mobile` an optional parameter for the `/api/v1/webhooks/customerio-gambit-broadcast` webhook.
- Adds check for `mobile`. If found, it sends the request to the new `origin=broadcastLite` route.
- Cleans up naming in the MessageFactory test helper

#### How should this be reviewed?
- 👀 
- Run all tests

#### Any background context you want to provide?
- This modification is necessary to allow the use of the new `origin=broadcastLite` route while keeping backwards compatibility for the `origin=broadcast` route.

#### Relevant tickets
Unblocks future work based on https://github.com/DoSomething/gambit-conversations/pull/407
Fixes a task in Pivotal [Card#160585940](https://www.pivotaltracker.com/story/show/160585940)

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [x] ENV variables added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
