### PR TITLE
Chore/remove signup campaign run id validation

### DIFF
--- a/src/messages/CampaignSignupMessage.js
+++ b/src/messages/CampaignSignupMessage.js
@@ -18,9 +18,7 @@ class CampaignSignupMessage extends Message {
         id: Joi.required().empty(whenNullOrEmpty),
         northstar_id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
         campaign_id: Joi.string().required().empty(whenNullOrEmpty),
-        campaign_run_id: Joi.string().required().empty(whenNullOrEmpty),
         source: Joi.string().empty(whenNullOrEmpty).default(undefined),
-        created_at: Joi.string().required().empty(whenNullOrEmpty).isoDate(),
       });
 
     this.eventName = 'campaign_signup';

--- a/src/messages/Message.js
+++ b/src/messages/Message.js
@@ -23,7 +23,6 @@ class Message {
     this.getRequestId = this.getRequestId.bind(this);
     this.toString = this.toString.bind(this);
     this.validate = this.validate.bind(this);
-    this.validateStrict = this.validateStrict.bind(this);
   }
 
   getData() {
@@ -116,10 +115,6 @@ class Message {
 
     this.payload.data = filtered || data;
     return true;
-  }
-
-  validateStrict() {
-    return this.validate(true);
   }
 
   static fromCtx(ctx) {

--- a/src/validations/campaignSignupPost.js
+++ b/src/validations/campaignSignupPost.js
@@ -13,7 +13,6 @@ const schema = Joi.object()
     northstar_id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
     type: Joi.string().required().empty(whenNullOrEmpty),
     action: Joi.string().required().empty(whenNullOrEmpty),
-    created_at: Joi.string().required().empty(whenNullOrEmpty).isoDate(), // Time stamp.
   });
 
 module.exports = schema;

--- a/src/validations/userCreateAndUpdate.js
+++ b/src/validations/userCreateAndUpdate.js
@@ -7,9 +7,6 @@ const whenNullOrEmpty = Joi.valid(['', null]);
 // Required minimum
 const schema = Joi.object().keys({
   id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
-  updated_at: Joi.required().empty(whenNullOrEmpty),
-  created_at: Joi.required().empty(whenNullOrEmpty),
-
   // Although this is NOT required to be sent, we make it implicitly required to exist in
   // the payload we send to C.io by declaring a default.
   // Allow anything as a role, but default to user.

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -78,7 +78,7 @@ class EventsWebController extends WebController {
   async userSignup(ctx) {
     try {
       const message = CampaignSignupMessage.fromCtx(ctx);
-      message.validateStrict();
+      message.validate();
       this.blink.broker.publishToRoute(
         'signup.user.event',
         message,

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -200,7 +200,6 @@ class MessageFactoryHelper {
         id: chance.integer({ min: 0 }),
         northstar_id: chance.hash({ length: 24 }),
         campaign_id: chance.string({ length: 4, pool: '1234567890' }),
-        campaign_run_id: chance.string({ length: 4, pool: '1234567890' }),
         quantity: null,
         why_participated: null,
         // Don't add sms signup here, they are tested separately.

--- a/test/helpers/MessageValidationHelper.js
+++ b/test/helpers/MessageValidationHelper.js
@@ -32,26 +32,6 @@ class MessageValidationHelper {
     });
     mutant.validate.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
   }
-
-  static removesWhenEmpty(fieldName, generator, mutator) {
-    let mutant;
-
-    mutant = mutator({
-      change: fieldName,
-      value: '',
-      message: generator(),
-    });
-    mutant.validateStrict();
-    mutant.getData().should.not.have.property(fieldName);
-
-    mutant = mutator({
-      change: fieldName,
-      value: null,
-      message: generator(),
-    });
-    mutant.validateStrict();
-    mutant.getData().should.not.have.property(fieldName);
-  }
 }
 
 module.exports = MessageValidationHelper;

--- a/test/helpers/MessageValidationHelper.js
+++ b/test/helpers/MessageValidationHelper.js
@@ -9,28 +9,28 @@ class MessageValidationHelper {
       remove: fieldName,
       message: generator(),
     });
-    mutant.validateStrict.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
+    mutant.validate.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
 
     mutant = mutator({
       change: fieldName,
       value: undefined,
       message: generator(),
     });
-    mutant.validateStrict.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
+    mutant.validate.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
 
     mutant = mutator({
       change: fieldName,
       value: null,
       message: generator(),
     });
-    mutant.validateStrict.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
+    mutant.validate.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
 
     mutant = mutator({
       change: fieldName,
       value: '',
       message: generator(),
     });
-    mutant.validateStrict.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
+    mutant.validate.should.throw(MessageValidationBlinkError, `"${fieldName}" is required`);
   }
 
   static removesWhenEmpty(fieldName, generator, mutator) {

--- a/test/integration/web/controllers/EventsWebController.test.js
+++ b/test/integration/web/controllers/EventsWebController.test.js
@@ -180,8 +180,8 @@ test('POST /api/v1/events/user-signup should publish message to user-signup-even
   cioMessageData.should.have.property('data');
   cioMessageData.data.should.be.eql({
     campaign_id: data.campaign_id,
-    campaign_run_id: data.campaign_run_id,
     created_at: data.created_at,
+    updated_at: data.updated_at,
     id: data.id,
     northstar_id: data.northstar_id,
     source: data.source,
@@ -195,8 +195,8 @@ test('POST /api/v1/events/user-signup should publish message to user-signup-even
   gambitMessageData.should.have.property('data');
   gambitMessageData.data.should.be.eql({
     campaign_id: data.campaign_id,
-    campaign_run_id: data.campaign_run_id,
     created_at: data.created_at,
+    updated_at: data.updated_at,
     id: data.id,
     northstar_id: data.northstar_id,
     source: data.source,

--- a/test/unit/messages/CampaignSignupMessage.test.js
+++ b/test/unit/messages/CampaignSignupMessage.test.js
@@ -44,7 +44,6 @@ test('Campaign signup message should be correctly transformed to CustomerIoEvent
 
     eventData.signup_id.should.equal(String(data.id));
     eventData.campaign_id.should.equal(data.campaign_id);
-    eventData.campaign_run_id.should.equal(data.campaign_run_id);
 
     // Todo: make sure TZ is corrected
     const originalCreatedAt = moment(data.created_at).milliseconds(0);

--- a/test/unit/messages/UserMessage.test.js
+++ b/test/unit/messages/UserMessage.test.js
@@ -44,8 +44,6 @@ test('Validate a hundred fake users', () => {
 test('User Message should fail if required fields are missing, undefined, null, or empty', () => {
   [
     'id',
-    'created_at',
-    'updated_at',
   ]
     .forEach(field => MessageValidationHelper.failsWithout(field, generator, mutator));
 });

--- a/test/unit/messages/UserMessage.test.js
+++ b/test/unit/messages/UserMessage.test.js
@@ -42,10 +42,7 @@ test('Validate a hundred fake users', () => {
 });
 
 test('User Message should fail if required fields are missing, undefined, null, or empty', () => {
-  [
-    'id',
-  ]
-    .forEach(field => MessageValidationHelper.failsWithout(field, generator, mutator));
+  ['id'].forEach(field => MessageValidationHelper.failsWithout(field, generator, mutator));
 });
 
 // ------- End -----------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
Fixes Blink not accepting signups w/ out run id.
Also removes a few more unneeded validations.
Validates the signup message but allows any non-null unknown key.

Blink will revisit the whole concept of validating messages in the near future. With this PR all messages are now doing **bare minimum** validations instead of strict validation that stripped unknown keys from the payloads.

#### How should this be reviewed?
- 👀 

#### Any background context you want to provide?
- The `user-signup` route was the last route using the 1st iteration of strict validation. The pivotal card that refactored all other validations is [#154736700](https://www.pivotaltracker.com/n/projects/2092734/stories/154736700)
- [Slack #dev-rogue thread about the issue](https://dosomething.slack.com/archives/C0YGXUE01/p1541109392023900)

#### Relevant tickets
Fixes Pivotal [Card#161667814](https://www.pivotaltracker.com/story/show/161667814)

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [x] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
