### PR TITLE
Adds new /api/v1/events/user-password-reset

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -3,6 +3,7 @@ customer-io-campaign-signup-post: npm run worker customer-io-campaign-signup-pos
 customer-io-campaign-signup-post-review: npm run worker customer-io-campaign-signup-post-review
 customer-io-campaign-signup: npm run worker customer-io-campaign-signup
 customer-io-gambit-broadcast: npm run worker customer-io-gambit-broadcast
+customer-io-password-reset: npm run worker customer-io-password-reset
 customer-io-sms-status-active: npm run worker customer-io-sms-status-active
 customer-io-update-customer: npm run worker customer-io-update-customer
 customer-io-email-unsubscribed-northstar: npm run worker customer-io-email-unsubscribed-northstar

--- a/config/lib/helpers/logger/transformers/leanify.js
+++ b/config/lib/helpers/logger/transformers/leanify.js
@@ -6,11 +6,14 @@ const enabled = process.env.BLINK_LOGGER_TRANSFORMER_LEANIFY === 'true';
 const bloatKeys = [
   'AccountSid',
   'ApiVersion',
+  'body',
   'deliveredAt',
   'failedAt',
   'MessagingServiceSid',
   'SmsMessageSid',
   'SmsSid',
+  'subject',
+  'url',
 ];
 
 module.exports = {

--- a/src/app/BlinkApp.js
+++ b/src/app/BlinkApp.js
@@ -16,6 +16,7 @@ const CustomerIoCampaignSignupPostQ = require('../queues/CustomerIoCampaignSignu
 const CustomerIoCampaignSignupPostReviewQ = require('../queues/CustomerIoCampaignSignupPostReviewQ');
 const CustomerIoCampaignSignupQ = require('../queues/CustomerIoCampaignSignupQ');
 const CustomerIoGambitBroadcastQ = require('../queues/CustomerIoGambitBroadcastQ');
+const CustomerIoPasswordResetQ = require('../queues/CustomerIoPasswordResetQ');
 const CustomerIoUpdateCustomerQ = require('../queues/CustomerIoUpdateCustomerQ');
 const CustomerIoSmsStatusActiveQ = require('../queues/CustomerIoSmsStatusActiveQ');
 const GambitCampaignSignupRelayQ = require('../queues/GambitCampaignSignupRelayQ');
@@ -166,6 +167,7 @@ class BlinkApp {
       CustomerIoCampaignSignupPostReviewQ,
       CustomerIoCampaignSignupQ,
       CustomerIoGambitBroadcastQ,
+      CustomerIoPasswordResetQ,
       CustomerIoUpdateCustomerQ,
       CustomerIoSmsStatusActiveQ,
       GambitCampaignSignupRelayQ,

--- a/src/app/BlinkWorkerApp.js
+++ b/src/app/BlinkWorkerApp.js
@@ -5,6 +5,7 @@ const CustomerIoCampaignSignupPostWorker = require('../workers/CustomerIoCampaig
 const CustomerIoCampaignSignupPostReviewWorker = require('../workers/CustomerIoCampaignSignupPostReviewWorker');
 const CustomerIoCampaignSignupWorker = require('../workers/CustomerIoCampaignSignupWorker');
 const CustomerIoGambitBroadcastWorker = require('../workers/CustomerIoGambitBroadcastWorker');
+const CustomerIoPasswordResetWorker = require('../workers/CustomerIoPasswordResetWorker');
 const CustomerIoSmsStatusActiveWorker = require('../workers/CustomerIoSmsStatusActiveWorker');
 const CustomerIoUpdateCustomerWorker = require('../workers/CustomerIoUpdateCustomerWorker');
 const CustomerIoEmailUnsubscribedNorthstarWorker = require('../workers/CustomerIoEmailUnsubscribedNorthstarWorker');
@@ -47,6 +48,7 @@ class BlinkWorkerApp extends BlinkApp {
       'customer-io-campaign-signup-post': CustomerIoCampaignSignupPostWorker,
       'customer-io-campaign-signup-post-review': CustomerIoCampaignSignupPostReviewWorker,
       'customer-io-gambit-broadcast': CustomerIoGambitBroadcastWorker,
+      'customer-io-password-reset': CustomerIoPasswordResetWorker,
       'customer-io-sms-status-active': CustomerIoSmsStatusActiveWorker,
       'customer-io-update-customer': CustomerIoUpdateCustomerWorker,
       'customer-io-email-unsubscribed-northstar': CustomerIoEmailUnsubscribedNorthstarWorker,

--- a/src/messages/PasswordResetMessage.js
+++ b/src/messages/PasswordResetMessage.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const CustomerIoEvent = require('../models/CustomerIoEvent');
+const Message = require('./Message');
+const schema = require('../validations/passwordReset');
+
+class PasswordResetMessage extends Message {
+  constructor(...args) {
+    super(...args);
+    // Data validation rules.
+    this.schema = schema;
+    this.eventName = 'password_reset';
+  }
+
+  /**
+   * toCustomerIoEvent - C.io segmentation filters distinguish
+   * between String, Number, and Date types. Because of this,
+   * we need to make sure the event properties, when passed,
+   * should be casted to the appropriate type for successful
+   * segmenting in C.io.
+   *
+   * TODO: DRY out functionality that will be used with all C.io events
+   *
+   * @return {CustomerIoEvent}
+   */
+  toCustomerIoEvent() {
+    const data = this.getData();
+    const eventData = {
+      type: data.type,
+      url: data.url,
+    };
+
+    const event = new CustomerIoEvent(
+      data.user_id,
+      this.eventName,
+      eventData,
+    );
+    // Password reset -> customer.io event transformation would only happen in this class.
+    // It's safe to hardcode schema event version here.
+    // Please bump it this when data schema changes.
+    event.setVersion(3);
+    return event;
+  }
+}
+
+module.exports = PasswordResetMessage;

--- a/src/messages/PasswordResetMessage.js
+++ b/src/messages/PasswordResetMessage.js
@@ -26,11 +26,10 @@ class PasswordResetMessage extends Message {
   toCustomerIoEvent() {
     const data = this.getData();
     const eventData = {
-      body_closing: data.body_closing,
-      body_greeting: data.body_greeting,
-      reset_label: data.reset_label,
-      reset_url: data.reset_url,
+      body: data.body,
       subject: data.subject,
+      type: data.type,
+      url: data.url,
     };
 
     const event = new CustomerIoEvent(

--- a/src/messages/PasswordResetMessage.js
+++ b/src/messages/PasswordResetMessage.js
@@ -26,8 +26,11 @@ class PasswordResetMessage extends Message {
   toCustomerIoEvent() {
     const data = this.getData();
     const eventData = {
-      type: data.type,
-      url: data.url,
+      body_closing: data.body_closing,
+      body_greeting: data.body_greeting,
+      reset_label: data.reset_label,
+      reset_url: data.reset_url,
+      subject: data.subject,
     };
 
     const event = new CustomerIoEvent(

--- a/src/queues/CustomerIoPasswordResetQ.js
+++ b/src/queues/CustomerIoPasswordResetQ.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const PasswordResetMessage = require('../messages/PasswordResetMessage');
+const Queue = require('../lib/Queue');
+
+class CustomerIoPasswordResetQ extends Queue {
+  constructor(...args) {
+    super(...args);
+    this.messageClass = PasswordResetMessage;
+    this.routes.push('password-reset.user.event');
+  }
+}
+
+module.exports = CustomerIoPasswordResetQ;

--- a/src/validations/passwordReset.js
+++ b/src/validations/passwordReset.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Joi = require('joi');
+
+const whenNullOrEmpty = Joi.valid(['', null]);
+
+// Required minimum.
+const schema = Joi.object()
+  .keys({
+    user_id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
+    type: Joi.string().required().empty(whenNullOrEmpty),
+    url: Joi.string().required().empty(whenNullOrEmpty),
+  });
+
+module.exports = schema;

--- a/src/validations/passwordReset.js
+++ b/src/validations/passwordReset.js
@@ -9,10 +9,9 @@ const schema = Joi.object()
   .keys({
     user_id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
     subject: Joi.string().required().empty(whenNullOrEmpty),
-    body_greeting: Joi.string().required().empty(whenNullOrEmpty),
-    body_closing: Joi.string().required().empty(whenNullOrEmpty),
-    reset_url: Joi.string().required().empty(whenNullOrEmpty),
-    reset_label: Joi.string().required().empty(whenNullOrEmpty),
+    body: Joi.string().required().empty(whenNullOrEmpty),
+    type: Joi.string().required().empty(whenNullOrEmpty),
+    url: Joi.string().required().empty(whenNullOrEmpty),
   });
 
 module.exports = schema;

--- a/src/validations/passwordReset.js
+++ b/src/validations/passwordReset.js
@@ -8,8 +8,11 @@ const whenNullOrEmpty = Joi.valid(['', null]);
 const schema = Joi.object()
   .keys({
     user_id: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
-    type: Joi.string().required().empty(whenNullOrEmpty),
-    url: Joi.string().required().empty(whenNullOrEmpty),
+    subject: Joi.string().required().empty(whenNullOrEmpty),
+    body_greeting: Joi.string().required().empty(whenNullOrEmpty),
+    body_closing: Joi.string().required().empty(whenNullOrEmpty),
+    reset_url: Joi.string().required().empty(whenNullOrEmpty),
+    reset_label: Joi.string().required().empty(whenNullOrEmpty),
   });
 
 module.exports = schema;

--- a/src/web/controllers/EventsWebController.js
+++ b/src/web/controllers/EventsWebController.js
@@ -4,6 +4,7 @@ const CampaignSignupMessage = require('../../messages/CampaignSignupMessage');
 const CampaignSignupPostMessage = require('../../messages/CampaignSignupPostMessage');
 const CampaignSignupPostReviewMessage = require('../../messages/CampaignSignupPostReviewMessage');
 const FreeFormMessage = require('../../messages/FreeFormMessage');
+const PasswordResetMessage = require('../../messages/PasswordResetMessage');
 const UserMessage = require('../../messages/UserMessage');
 const WebController = require('./WebController');
 const basicAuthStrategy = require('../middleware/auth/strategies/basicAuth');
@@ -24,6 +25,12 @@ class EventsWebController extends WebController {
       '/api/v1/events/user-create',
       basicAuthStrategy(this.blink.config.app.auth),
       this.userCreate.bind(this),
+    );
+    this.router.post(
+      'v1.events.user-password-reset',
+      '/api/v1/events/user-password-reset',
+      basicAuthStrategy(this.blink.config.app.auth),
+      this.userPasswordReset.bind(this),
     );
     this.router.post(
       'v1.events.user-signup',
@@ -54,6 +61,7 @@ class EventsWebController extends WebController {
   async index(ctx) {
     ctx.body = {
       'user-create': this.fullUrl('v1.events.user-create'),
+      'user-password-reset': this.fullUrl('v1.events.user-password-reset'),
       'user-signup': this.fullUrl('v1.events.user-signup'),
       'user-signup-post': this.fullUrl('v1.events.user-signup-post'),
       'user-signup-post-review': this.fullUrl('v1.events.user-signup-post-review'),
@@ -70,6 +78,20 @@ class EventsWebController extends WebController {
         userMessage,
       );
       this.sendOK(ctx, userMessage);
+    } catch (error) {
+      this.sendError(ctx, error);
+    }
+  }
+
+  async userPasswordReset(ctx) {
+    try {
+      const message = PasswordResetMessage.fromCtx(ctx);
+      message.validate();
+      this.blink.broker.publishToRoute(
+        'password-reset.user.event',
+        message,
+      );
+      this.sendOK(ctx, message);
     } catch (error) {
       this.sendError(ctx, error);
     }

--- a/src/workers/CustomerIoPasswordResetWorker.js
+++ b/src/workers/CustomerIoPasswordResetWorker.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const CustomerIoTrackEventWorker = require('./CustomerIoTrackEventWorker');
+
+class CustomerIoPasswordResetWorker extends CustomerIoTrackEventWorker {
+  setup() {
+    super.setup({
+      queue: this.blink.queues.customerIoPasswordResetQ,
+      eventName: 'track_password_reset',
+    });
+  }
+}
+
+module.exports = CustomerIoPasswordResetWorker;

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -11,6 +11,7 @@ const CustomerIoSmsStatusActiveMessage = require('../../src/messages/CustomerIoS
 const CampaignSignupPostReviewMessage = require('../../src/messages/CampaignSignupPostReviewMessage');
 const CustomerIoUpdateCustomerMessage = require('../../src/messages/CustomerIoUpdateCustomerMessage');
 const CustomerIoGambitBroadcastMessage = require('../../src/messages/CustomerIoGambitBroadcastMessage');
+const PasswordResetMessage = require('../../src/messages/PasswordResetMessage');
 const FreeFormMessage = require('../../src/messages/FreeFormMessage');
 const TwilioOutboundStatusCallbackMessage = require('../../src/messages/TwilioOutboundStatusCallbackMessage');
 const CustomerIoWebhookMessage = require('../../src/messages/CustomerIoWebhookMessage');
@@ -263,6 +264,18 @@ class MessageFactoryHelper {
     return new CampaignSignupPostReviewMessage({
       data,
       meta: {},
+    });
+  }
+
+  static getPasswordResetMessage() {
+    return new PasswordResetMessage({
+      data: {
+        body: chance.sentence({ words: 25 }),
+        user_id: chance.hash({ length: 24 }),
+        subject: chance.sentence({ words: 3 }),
+        type: chance.pickone(['forgot-password', 'rtv-activate-account']),
+        url: chance.url({ path: 'reset' }),
+      },
     });
   }
 

--- a/test/unit/messages/PasswordResetMessage.test.js
+++ b/test/unit/messages/PasswordResetMessage.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// ------- Imports -------------------------------------------------------------
+
+const test = require('ava');
+const chai = require('chai');
+
+const PasswordResetMessage = require('../../../src/messages/PasswordResetMessage');
+const CustomerIoEvent = require('../../../src/models/CustomerIoEvent');
+const MessageFactoryHelper = require('../../helpers/MessageFactoryHelper');
+
+// ------- Init ----------------------------------------------------------------
+
+chai.should();
+const expect = chai.expect;
+const generator = MessageFactoryHelper.getPasswordResetMessage;
+
+// ------- Tests ---------------------------------------------------------------
+
+test('Password reset message generator', () => {
+  generator().should.be.an.instanceof(PasswordResetMessage);
+});
+
+test('Password reset message should have toCustomerIoEvent', () => {
+  generator().should.respondsTo('toCustomerIoEvent');
+});
+
+test('Password reset message should be correctly transformed to CustomerIoEvent', () => {
+  let count = 100;
+  while (count > 0) {
+    const msg = generator();
+    const data = msg.getData();
+    const cioEvent = msg.toCustomerIoEvent();
+
+    expect(cioEvent).to.be.an.instanceof(CustomerIoEvent);
+
+    cioEvent.getId().should.equal(data.user_id);
+    cioEvent.getName().should.equal('password_reset');
+
+    const eventData = cioEvent.getData();
+    eventData.version.should.equal(3);
+
+    eventData.body.should.equal(data.body);
+    eventData.subject.should.equal(data.subject);
+    eventData.type.should.equal(data.type);
+    eventData.url.should.equal(data.url);
+
+    count -= 1;
+  }
+});
+
+// ------- End -----------------------------------------------------------------

--- a/test/unit/messages/PasswordResetMessage.test.js
+++ b/test/unit/messages/PasswordResetMessage.test.js
@@ -40,6 +40,7 @@ test('Password reset message should be correctly transformed to CustomerIoEvent'
     const eventData = cioEvent.getData();
     eventData.version.should.equal(3);
 
+    cioEvent.getId().should.equal(data.user_id);
     eventData.body.should.equal(data.body);
     eventData.subject.should.equal(data.subject);
     eventData.type.should.equal(data.type);


### PR DESCRIPTION
#### What's this PR do?

Adds a new API endpoint to create `password_reset` events in Customer.io, which we'll eventually use for Customer.io event triggered campaigns for sending Forgot Password emails from Northstar, or Account Activation emails from Chompy.

* Adds new `customer-io-password-reset` queue and corresponding worker

#### How should this be reviewed?

Here's an example request for localhost:

```
curl -X POST \
  http://localhost:5050/api/v1/events/user-password-reset \
  -H 'Authorization: Basic [removed]=' \
  -H 'Content-Type: application/json' \
  -d '{
    "user_id": "yourNorthstarId",
    "subject": "Reset Password",
    "body": "<h3>Hello!</h3><p>You are receiving this email because we received a password reset request for your DoSomething.org account. Here is the link to reset your password: http://puppetsloth.com</p>",
    "url": "http://puppetsloth.com",
    "type": "Reset Password"
}'
```

 I've set up an event riggered campaign in our Customer.io staging instance that will send an email to given `user_id` param with the various `password_event` properties upon creation.

<img width="504" alt="screen shot 2019-02-25 at 11 24 48 am" src="https://user-images.githubusercontent.com/1236811/53362866-03e29c00-38f0-11e9-88ef-007ee9a25cf6.png">


#### Any background context you want to provide?

Background info in [technical spec](https://docs.google.com/document/d/1RbWAAJA-zTfQYv6dBVIcpJqegKJUM0dH4DkVpikRpE0/edit#).

#### Relevant tickets

https://www.pivotaltracker.com/story/show/163779567

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
