### PR TITLE
Adds CallToActionEmailMessage.type

### DIFF
--- a/src/messages/CallToActionEmailMessage.js
+++ b/src/messages/CallToActionEmailMessage.js
@@ -31,6 +31,7 @@ class CallToActionEmailMessage extends Message {
       intro: data.intro,
       outro: data.outro,
       subject: data.subject,
+      type: data.type,
     };
 
     const event = new CustomerIoEvent(

--- a/src/validations/callToActionEmail.js
+++ b/src/validations/callToActionEmail.js
@@ -7,11 +7,13 @@ const whenNullOrEmpty = Joi.valid(['', null]);
 // Required minimum.
 const schema = Joi.object()
   .keys({
-    actionText: Joi.string().required().empty(whenNullOrEmpty),
+    actionText: Joi.string().empty(whenNullOrEmpty),
     actionUrl: Joi.string().required().empty(whenNullOrEmpty),
-    intro: Joi.string().required().empty(whenNullOrEmpty),
-    outro: Joi.string().required().empty(whenNullOrEmpty),
-    subject: Joi.string().required().empty(whenNullOrEmpty),
+    intro: Joi.string().empty(whenNullOrEmpty),
+    outro: Joi.string().empty(whenNullOrEmpty),
+    subject: Joi.string().empty(whenNullOrEmpty),
+    // TODO: This should be required once Northstar starts sending it.
+    type: Joi.string().empty(whenNullOrEmpty),
     userId: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
   });
 

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -276,6 +276,7 @@ class MessageFactoryHelper {
         outro: chance.sentence({ words: 22 }),
         userId: chance.hash({ length: 24 }),
         subject: chance.sentence({ words: 3 }),
+        type: chance.word(),
       },
     });
   }

--- a/test/unit/messages/CallToActionEmailMessage.test.js
+++ b/test/unit/messages/CallToActionEmailMessage.test.js
@@ -46,6 +46,7 @@ test('Call to action email message should be correctly transformed to CustomerIo
     eventData.intro.should.equal(data.intro);
     eventData.outro.should.equal(data.outro);
     eventData.subject.should.equal(data.subject);
+    eventData.type.should.equal(data.type);
 
     count -= 1;
   }


### PR DESCRIPTION
#### What's this PR do?

* Adds an optional `type` parameter for creating a `call_to_action_email` event in Customer.io. This will eventually be changed to required once Northstar starts sending one.

* Changes properties from required to optional: `intro`, `outro`, `subject,`, and `actionText` per https://github.com/orgs/DoSomething/teams/team-bleed/discussions/34

#### How should this be reviewed?

Verify `type` attribute appears in a Customer.io `call_to_action_email` event when including in a `POST /v1/events/user-call-to-action-email` request.

#### Any background context you want to provide?

Because so many of the rules for who to send to are defined in our Customer.io environments, I think it's overall easier to maintain the email content from within Customer.io as well, instead of the apps that create the events.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/163779567

#### Checklist
- [ ] Documentation added for new features/changed endpoints. - will update upon merge
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
