### PR TITLE
Require CallToActionEmail.type parameter

### DIFF
--- a/src/validations/callToActionEmail.js
+++ b/src/validations/callToActionEmail.js
@@ -12,8 +12,7 @@ const schema = Joi.object()
     intro: Joi.string().empty(whenNullOrEmpty),
     outro: Joi.string().empty(whenNullOrEmpty),
     subject: Joi.string().empty(whenNullOrEmpty),
-    // TODO: This should be required once Northstar starts sending it.
-    type: Joi.string().empty(whenNullOrEmpty),
+    type: Joi.string().required(whenNullOrEmpty),
     userId: Joi.string().required().empty(whenNullOrEmpty).regex(/^[0-9a-f]{24}$/, 'valid object id'),
   });
 

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -271,7 +271,7 @@ class MessageFactoryHelper {
     return new CallToActionEmailMessage({
       data: {
         actionText: chance.sentence({ words: 2 }),
-        actionUrl: chance.url(),
+        actionUrl: MessageFactoryHelper.getRandomUrl(),
         intro: chance.sentence({ words: 25 }),
         outro: chance.sentence({ words: 22 }),
         userId: chance.hash({ length: 24 }),
@@ -329,6 +329,10 @@ class MessageFactoryHelper {
     // Todo: add option to set message tag.
     rabbitMessage.content = Buffer.from(contentString);
     return rabbitMessage;
+  }
+
+  static getRandomUrl() {
+    return chance.url();
   }
 
   static getFakeMobileNumber() {

--- a/test/integration/web/controllers/EventsWebController.test.js
+++ b/test/integration/web/controllers/EventsWebController.test.js
@@ -160,6 +160,57 @@ test('POST /api/v1/events/user-call-to-action-email should publish message to us
   messageData.data.subject.should.be.eql(data.subject);
 });
 
+test('POST /api/v1/events/user-call-to-action-email should return error if missing actionUrl parameter', async (t) => {
+  const data = {
+    id: MessageFactoryHelper.getFakeUserId(),
+    type: MessageFactoryHelper.getBroadcastId(),
+  };
+
+  const res = await t.context.supertest.post('/api/v1/events/user-call-to-action-email')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(422);
+
+  // Check response to be json
+  res.header.should.have.property('content-type');
+  res.header['content-type'].should.match(/json/);
+});
+
+test('POST /api/v1/events/user-call-to-action-email should return error if missing id parameter', async (t) => {
+  const data = {
+    actionUrl: MessageFactoryHelper.getRandomUrl(),
+    type: MessageFactoryHelper.getBroadcastId(),
+  };
+
+  const res = await t.context.supertest.post('/api/v1/events/user-call-to-action-email')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(422);
+
+  // Check response to be json
+  res.header.should.have.property('content-type');
+  res.header['content-type'].should.match(/json/);
+});
+
+test('POST /api/v1/events/user-call-to-action-email should return error if missing type parameter', async (t) => {
+  const data = {
+    actionUrl: MessageFactoryHelper.getRandomUrl(),
+    id: MessageFactoryHelper.getFakeUserId(),
+  };
+
+  const res = await t.context.supertest.post('/api/v1/events/user-call-to-action-email')
+    .auth(t.context.config.app.auth.name, t.context.config.app.auth.password)
+    .send(data);
+
+  res.status.should.be.equal(422);
+
+  // Check response to be json
+  res.header.should.have.property('content-type');
+  res.header['content-type'].should.match(/json/);
+});
+
 /**
  * POST /api/v1/events/user-signup
  */


### PR DESCRIPTION
#### What's this PR do?

Changes `type` parameter in a `call_to_action_email` Customer.io event as required instead of optional. This type parameter is what's used to determine what email to send via [Event Triggered Campaigns](http://docs.dosomething.org/customer-io#call-to-action-email).

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
We're looking to start a new type of `call_to_action_email` event for opt-ins from Content pages in Phoenix - sounds like a good time to start requiring this field now that Northstar sends over per https://github.com/DoSomething/northstar/pull/847 (cc @katiecrane)

#### Checklist
- [ ] Documentation added for new features/changed endpoints - will update
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
