### PR TITLE
Properly encode JSON body for Northstar API call.

### DIFF
--- a/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
+++ b/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
@@ -30,7 +30,7 @@ class CustomerIoEmailUnsubscribedNorthstarWorker extends NorthstarRelayBaseWorke
     try {
       const response = await northstarHelper.updateUserById(userId, {
         headers,
-        body,
+        body: JSON.stringify(body),
       });
       return this.handleResponse(message, response);
     } catch (error) {


### PR DESCRIPTION
#### What's this PR do?
This pull request wraps the `body` for the Northstar unsubscribe request in `JSON.stringify` so that it isn't sent as a rather unhelpful `[object Object]` string.

#### How should this be reviewed?
Compare the change in e27c4b9 with [node-fetch's documentation](https://github.com/bitinn/node-fetch#post-with-json). We already set the `Content-Type: application/json` header in `northstarHelper.getRequestHeaders`, so the only necessary change was stringifying the object.

#### Any background context you want to provide?
This means we haven't been properly setting `email_subscription_status` for any users that hit the "unsubscribe" link in an email footer, so we'll need to [re-import those updates](https://www.pivotaltracker.com/story/show/166361521) after deploying this fix.

#### Relevant tickets
Fixes Pivotal [#166361430](https://www.pivotaltracker.com/story/show/166361430).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.