### PR TITLE
Cio northstar unsubscribed events patch

### DIFF
--- a/src/errors/BlinkSendToDLXError.js
+++ b/src/errors/BlinkSendToDLXError.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const BlinkError = require('./BlinkError');
+
+class BlinkSendToDLXError extends BlinkError {
+  constructor(errorMessage, blinkMessage) {
+    super(errorMessage);
+    this.blinkMessage = blinkMessage;
+  }
+}
+
+module.exports = BlinkSendToDLXError;

--- a/src/messages/CustomerIoWebhookMessage.js
+++ b/src/messages/CustomerIoWebhookMessage.js
@@ -23,6 +23,10 @@ class CustomerIoWebhookMessage extends Message {
     return this.getData().data.customer_id;
   }
 
+  getEventTimestamp() {
+    return this.getData().timestamp;
+  }
+
   getEventType() {
     return this.getData().event_type;
   }

--- a/test/helpers/MessageFactoryHelper.js
+++ b/test/helpers/MessageFactoryHelper.js
@@ -383,9 +383,11 @@ class MessageFactoryHelper {
     };
   }
 
-  static getCustomerIoWebhookMessage(eventType) {
+  static getCustomerIoWebhookMessage(eventType, timestamp) {
     const data = MessageFactoryHelper.getCustomerIoWebhookData();
     data.event_type = eventType || chance.word();
+    data.timestamp = timestamp || chance.timestamp();
+
     return new CustomerIoWebhookMessage({
       data,
       meta: {},

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -9,6 +9,7 @@ const RabbitManagement = require('../../../helpers/RabbitManagement');
 const HooksHelper = require('../../../helpers/HooksHelper');
 const MessageFactoryHelper = require('../../../helpers/MessageFactoryHelper');
 const twilioHelper = require('../../../helpers/twilio');
+const CustomerIoEmailUnsubscribedNorthstarWorker = require('../../../../src/workers/CustomerIoEmailUnsubscribedNorthstarWorker');
 
 // ------- Init ----------------------------------------------------------------
 
@@ -113,6 +114,44 @@ test.serial('POST /api/v1/webhooks/customerio-email-activity should publish emai
     messageData.should.have.property('data');
     messageData.data.should.be.eql(data);
   });
+});
+
+// This test should be in it's own CustomerIoEmailUnsubscribedNorthstarWorker.test.js file.
+// But because it would interfere with the previous test.
+// It must run after the previous serial test above.
+test.serial('A customer unsubscribed event w/ timestamp in between range of the backfill should be put on the dead letter exchange', async (t) => {
+  const blink = t.context.blink;
+  const { quasarCustomerIoEmailUnsubscribedQ } = blink.queues;
+
+  const eventName = 'email_unsubscribed';
+  const timestamp = new Date('2020-04-15').getTime();
+  const message = MessageFactoryHelper.getCustomerIoWebhookMessage(eventName, timestamp);
+  const data = message.getData();
+  message.validate();
+  quasarCustomerIoEmailUnsubscribedQ.publish(message);
+
+  const worker = new CustomerIoEmailUnsubscribedNorthstarWorker(blink);
+
+  worker.setup();
+  worker.start();
+
+  // Await consuming to complete
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  const rabbit = new RabbitManagement(t.context.config.amqpManagement);
+  const result = await rabbit.getMessagesFrom('quasar-customer-io-email-unsubscribed', 1, false);
+  // The message should not exist
+  result.should.be.an('array').and.to.have.lengthOf(0);
+
+  const deadLetterQueueResult = await rabbit.getMessagesFrom('blink-dlx', 1, false);
+  // The message should exist in the deadLetter exchange queue
+  // NOTE: Manually created in RabbitMQ
+  deadLetterQueueResult.should.be.an('array').and.to.have.lengthOf(1);
+  deadLetterQueueResult[0].should.have.property('payload');
+  const payload = deadLetterQueueResult[0].payload;
+  const messageData = JSON.parse(payload);
+  messageData.should.have.property('data');
+  messageData.data.should.be.eql(data);
 });
 
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -62,7 +62,7 @@ build:
         name: Setup dead letter queue binding
         code: |
           curl -i -u $RABBITMQ_ENV_RABBITMQ_DEFAULT_USER:$RABBITMQ_ENV_RABBITMQ_DEFAULT_PASS -H "Content-Type: application/json" -X POST \
-          -d '{"routing-key": "*"}' \
+          -d '{"routing_key": "*"}' \
           http://$RABBITMQ_PORT_15672_TCP_ADDR:$RABBITMQ_PORT_15672_TCP_PORT/api/bindings/$RABBITMQ_ENV_RABBITMQ_DEFAULT_VHOST/e/blink-dlx/q/blink-dlx -v
     - script:
         name: run lint, BDD tests and code coverage

--- a/wercker.yml
+++ b/wercker.yml
@@ -9,6 +9,9 @@ services:
 build:
   steps:
     - script:
+      name: install netcat
+      code: apt-get update && apt-get install --assume-yes netcat
+    - script:
       name: install yarn
       code: npm install -g yarn@1.13.0
     - script:
@@ -29,6 +32,38 @@ build:
           export BLINK_AMQP_MANAGEMENT_PORT=$RABBITMQ_PORT_15672_TCP_PORT
           export BLINK_REDIS_HOST=$REDIS_PORT_6379_TCP_ADDR
           export BLINK_REDIS_PORT=$REDIS_PORT_6379_TCP_PORT
+    - script:
+        name: env
+        code: |
+          env
+    - franciscocpg/step-wait-tcp:
+        host: $RABBITMQ_PORT_15672_TCP_ADDR
+        port: $RABBITMQ_PORT_15672_TCP_PORT
+        timeout: 20
+    - script:
+        name: Create dead letter exchange
+        code: |
+          curl -i -u $RABBITMQ_ENV_RABBITMQ_DEFAULT_USER:$RABBITMQ_ENV_RABBITMQ_DEFAULT_PASS -H "Content-Type: application/json" -X PUT \
+          -d '{"type":"topic","durable": true}' \
+          http://$RABBITMQ_PORT_15672_TCP_ADDR:$RABBITMQ_PORT_15672_TCP_PORT/api/exchanges/$RABBITMQ_ENV_RABBITMQ_DEFAULT_VHOST/blink-dlx -v
+    - script:
+        name: Create dead letter queue
+        code: |
+          curl -i -u $RABBITMQ_ENV_RABBITMQ_DEFAULT_USER:$RABBITMQ_ENV_RABBITMQ_DEFAULT_PASS -H "Content-Type: application/json" -X PUT \
+          -d '{"arguments":{ "x-queue-type": "classic", "x-max-priority": 2},"durable": true}' \
+          http://$RABBITMQ_PORT_15672_TCP_ADDR:$RABBITMQ_PORT_15672_TCP_PORT/api/queues/$RABBITMQ_ENV_RABBITMQ_DEFAULT_VHOST/blink-dlx -v
+    - script:
+        name: Setup dead letter exchange Policy
+        code: |
+          curl -i -u $RABBITMQ_ENV_RABBITMQ_DEFAULT_USER:$RABBITMQ_ENV_RABBITMQ_DEFAULT_PASS -H "Content-Type: application/json" -X PUT \
+          -d '{"pattern":"quasar-customer-io-email-unsubscribed","definition":{"dead-letter-exchange":"blink-dlx"},"apply-to": "queues"}' \
+          http://$RABBITMQ_PORT_15672_TCP_ADDR:$RABBITMQ_PORT_15672_TCP_PORT/api/policies/$RABBITMQ_ENV_RABBITMQ_DEFAULT_VHOST/cio-user-unsubscribed-northstar-dlx -v
+    - script:
+        name: Setup dead letter queue binding
+        code: |
+          curl -i -u $RABBITMQ_ENV_RABBITMQ_DEFAULT_USER:$RABBITMQ_ENV_RABBITMQ_DEFAULT_PASS -H "Content-Type: application/json" -X POST \
+          -d '{"routing-key": "*"}' \
+          http://$RABBITMQ_PORT_15672_TCP_ADDR:$RABBITMQ_PORT_15672_TCP_PORT/api/bindings/$RABBITMQ_ENV_RABBITMQ_DEFAULT_VHOST/e/blink-dlx/q/blink-dlx -v
     - script:
         name: run lint, BDD tests and code coverage
         code: yarn test:full


### PR DESCRIPTION
#### What's this PR do?
- When a `user_unsubscribed` C.io event timestamp's is between `2020-04-01` and `2020-05-05`. It sends the event into the `blink-dlx` (dead letter) queue. Without updating the user's profile in Northstar.

#### NOTES

- This is meant to be a temporary patch to enable backfilling C.io's email events for the month of April and a few days of May. Will be removed after the backfill!

- Dead letter exchange is being setup through the RabbitMQ Management plugin as a Policy instead of passed arguments when asserting queues in code.

- `blink-dlx` dead letter was setup manually for simplicity.

#### How should this be reviewed?
- 👀 
- Run tests (if dev setup)


#### Relevant tickets
Unblocks backfill for Pivotal [Card#172585118](https://www.pivotaltracker.com/story/show/172585118)
Fixes Pivotal [Card#172654252](https://www.pivotaltracker.com/story/show/172654252)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
