### PR TITLE
Fixes parsing of C.io event timestamp to correct format

### DIFF
--- a/src/messages/CustomerIoWebhookMessage.js
+++ b/src/messages/CustomerIoWebhookMessage.js
@@ -14,6 +14,7 @@ class CustomerIoWebhookMessage extends Message {
       data: Joi.object().required(),
       event_id: Joi.string().required(),
       event_type: Joi.string().required(),
+      // Sent to us as Unix timestamp (seconds)
       timestamp: Joi.number().integer().required(),
     });
   }
@@ -25,6 +26,10 @@ class CustomerIoWebhookMessage extends Message {
 
   getEventTimestamp() {
     return this.getData().timestamp;
+  }
+
+  getEventTimestampInMilliseconds() {
+    return this.getData().timestamp * 1000;
   }
 
   getEventType() {

--- a/src/messages/CustomerIoWebhookMessage.js
+++ b/src/messages/CustomerIoWebhookMessage.js
@@ -28,6 +28,8 @@ class CustomerIoWebhookMessage extends Message {
     return this.getData().timestamp;
   }
 
+  // TODO: return Date object per https://github.com/DoSomething/blink/pull/247#discussion_r423854150
+  // when date-fns is updated to latest version that supports https://date-fns.org/v2.13.0/docs/fromUnixTime
   getEventTimestampInMilliseconds() {
     return this.getData().timestamp * 1000;
   }

--- a/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
+++ b/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
@@ -27,7 +27,7 @@ class CustomerIoEmailUnsubscribedNorthstarWorker extends NorthstarRelayBaseWorke
     const userId = message.getUserId();
 
     // TODO: Remove patch when https://www.pivotaltracker.com/story/show/172585118 is accepted
-    const eventTimestamp = message.getEventTimestamp();
+    const eventTimestamp = message.getEventTimestampInMilliseconds();
     const startDate = new Date('2020-04-01');
     const endDate = new Date('2020-05-05');
 

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -124,7 +124,7 @@ test.serial('A customer unsubscribed event w/ timestamp in between range of the 
   const { quasarCustomerIoEmailUnsubscribedQ } = blink.queues;
 
   const eventName = 'email_unsubscribed';
-  const timestamp = new Date('2020-04-15').getTime();
+  const timestamp = Math.floor(new Date('2020-04-15').getTime() / 1000);
   const message = MessageFactoryHelper.getCustomerIoWebhookMessage(eventName, timestamp);
   const data = message.getData();
   message.validate();


### PR DESCRIPTION
#### What's this PR do?
Fixes logic that checks if the C.io `user_unsubscribed` event's timestamp falls within the backfill date range.

It adds a new `getEventTimestampInMilliseconds` method to get Unix Timestamp (seconds) in milliseconds.

#### Relevant tickets
Fixes Pivotal [Card#172782220](https://www.pivotaltracker.com/story/show/172782220)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
