### PR TITLE
Fix Customer.io webhooks for deleted customers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": "8.16",
     "npm": "6.4.1",
-    "yarn": "1.13.0"
+    "yarn": "1.22.4"
   },
   "scripts": {
     "test": "npm run test:unit",

--- a/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
+++ b/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
@@ -28,6 +28,13 @@ class CustomerIoEmailUnsubscribedNorthstarWorker extends NorthstarRelayBaseWorke
     };
     const headers = await northstarHelper.getRequestHeaders(message);
 
+    // If we're missing a `customer_id` on the incoming message, that means
+    // means that this user has been deleted from Customer.io & thus we don't
+    // need to forward this event on to Northstar (and, without an ID, couldn't!)
+    if (!userId) {
+      return this.logSuppressedRetry(message, 200, 'skipping due to missing customer_id');
+    }
+
     try {
       const response = await northstarHelper.updateUserById(userId, {
         headers,

--- a/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
+++ b/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
@@ -29,8 +29,8 @@ class CustomerIoEmailUnsubscribedNorthstarWorker extends NorthstarRelayBaseWorke
     const headers = await northstarHelper.getRequestHeaders(message);
 
     // If we're missing a `customer_id` on the incoming message, that means
-    // means that this user has been deleted from Customer.io & thus we don't
-    // need to forward this event on to Northstar (and, without an ID, couldn't!)
+    // that this user has been deleted from Customer.io & thus we don't need
+    // to forward this event on to Northstar (and, without an ID, couldn't!)
     if (!userId) {
       return this.logSuppressedRetry(message, 200, 'skipping due to missing customer_id');
     }

--- a/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
+++ b/src/workers/CustomerIoEmailUnsubscribedNorthstarWorker.js
@@ -1,10 +1,7 @@
 'use strict';
 
-const dateFns = require('date-fns');
-
 const NorthstarRelayBaseWorker = require('./NorthstarRelayBaseWorker');
 const northstarHelper = require('./lib/helpers/northstar');
-const BlinkSendToDLXError = require('../errors/BlinkSendToDLXError');
 
 const logCodes = {
   retry: 'error_customerio_email_unsubscribed_northstar_response_not_200_retry',
@@ -25,16 +22,6 @@ class CustomerIoEmailUnsubscribedNorthstarWorker extends NorthstarRelayBaseWorke
 
   async consume(message) {
     const userId = message.getUserId();
-
-    // TODO: Remove patch when https://www.pivotaltracker.com/story/show/172585118 is accepted
-    const eventTimestamp = message.getEventTimestampInMilliseconds();
-    const startDate = new Date('2020-04-01');
-    const endDate = new Date('2020-05-05');
-
-    if (dateFns.isWithinRange(eventTimestamp, startDate, endDate)) {
-      // Send to DeadLetter Exchange "Blink-dlx"
-      throw new BlinkSendToDLXError('skip this message', message);
-    }
 
     const body = {
       [this.emailUnsubscribedProperty]: this.emailUnsubscribedValue,

--- a/test/integration/web/controllers/WebHooksWebController.test.js
+++ b/test/integration/web/controllers/WebHooksWebController.test.js
@@ -12,6 +12,7 @@ const RabbitManagement = require('../../../helpers/RabbitManagement');
 const HooksHelper = require('../../../helpers/HooksHelper');
 const MessageFactoryHelper = require('../../../helpers/MessageFactoryHelper');
 const twilioHelper = require('../../../helpers/twilio');
+
 const CustomerIoEmailUnsubscribedNorthstarWorker = rewire('../../../../src/workers/CustomerIoEmailUnsubscribedNorthstarWorker');
 const northstarHelper = rewire('../../../../src/workers/lib/helpers/northstar');
 
@@ -135,8 +136,8 @@ test.serial('A customer unsubscribed event w/o customer_id should be suppressed'
 
   const updateUserById = sinon.stub();
   CustomerIoEmailUnsubscribedNorthstarWorker.__set__({
-    northstarHelper: { updateUserById }
-  })
+    northstarHelper: { updateUserById },
+  });
 
   // Create a message without a customer_id:
   const message = MessageFactoryHelper.getCustomerIoWebhookMessage('email_unsubscribed');

--- a/wercker.yml
+++ b/wercker.yml
@@ -13,7 +13,7 @@ build:
       code: apt-get update && apt-get install --assume-yes netcat
     - script:
       name: install yarn
-      code: npm install -g yarn@1.13.0
+      code: npm install -g yarn@1.22.4
     - script:
       name: report yarn version
       code: yarn --version


### PR DESCRIPTION
#### What's this PR do?
This pull request suppresses any incoming Customer.io webhook events that don't have `data.customer_id`. This should fix some errors we were seeing on incoming messages from users whose Customer.io accounts we'd deleted. 

#### How should this be reviewed?

🧶 I upgraded the pinned Yarn version in d211b46 to match what I'm running locally (rather than try to downgrade my own yarn to the exact pinned release). Is there a better way for me manage this on my end?

🩹 Removed a patch for an [old issue](https://www.pivotaltracker.com/story/show/172585118) that's since been resolved in 134e1c4.

🔇 If we don't have a `userId`, then suppress to bypass making a Northstar request & not retry. ba407ad

#### Any background context you want to provide?
This application still uses Wercker for CI, which we haven't configured for [their new rate limits](https://docs.docker.com/docker-hub/download-rate-limit/):

```
could not fetch service docker.io/library/redis:3.2.12: fetch failed to pull image redis: API error (500): {"message":"toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"}
```

I've run tests locally to confirm that everything's still green:

![Screen Shot 2021-06-11 at 12 12 57 PM](https://user-images.githubusercontent.com/583202/121716734-6276b880-caae-11eb-9fc6-cc1127c60a79.png)

#### Relevant tickets
Fixes Pivotal [#178457763](https://www.pivotaltracker.com/story/show/178457763).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
